### PR TITLE
Update for 0.4.0 breaking changes.

### DIFF
--- a/assets/templates/components/state-store.yaml
+++ b/assets/templates/components/state-store.yaml
@@ -9,3 +9,5 @@ spec:
     value: {{redisHost}}:6379
   - name: redisPassword
     value: ""
+  - name: actorStateStore
+    value: "true"

--- a/samples/dotnetcore/.vscode/launch.json
+++ b/samples/dotnetcore/.vscode/launch.json
@@ -4,23 +4,22 @@
    // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
    "version": "0.2.0",
    "configurations": [
-        {
-            "name": ".NET Core Launch (web)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "daprd-debug",
-            "postDebugTask": "daprd-down",
-            // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/bin/Debug/netcoreapp3.0/App.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}",
-            "stopAtEntry": false,
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            },
-            "sourceFileMap": {
-                "/Views": "${workspaceFolder}/Views"
-            }
+    {
+        "name": ".NET Core Launch (web)",
+        "type": "coreclr",
+        "request": "launch",
+        "preLaunchTask": "daprd-debug",
+        "postDebugTask": "daprd-down",
+        "program": "${workspaceFolder}/bin/Debug/netcoreapp3.1/App.dll",
+        "args": [],
+        "cwd": "${workspaceFolder}",
+        "stopAtEntry": false,
+        "env": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "sourceFileMap": {
+            "/Views": "${workspaceFolder}/Views"
         }
-    ]
+    }
+]
 }

--- a/samples/dotnetcore/.vscode/tasks.json
+++ b/samples/dotnetcore/.vscode/tasks.json
@@ -14,24 +14,6 @@
             "problemMatcher": "$msCompile"
         },
         {
-            "label": "daprd-up",
-            "type": "daprd",
-            "appId": "accounts",
-            "appPort": 5000,
-        },
-        {
-            "label": "daprd-debug",
-            "type": "daprd",
-            "appId": "accounts",
-            "appPort": 5000,
-            "dependsOn": "build"
-        },
-        {
-            "label": "daprd-down",
-            "type": "daprd-down",
-            "appId": "accounts"
-        },
-        {
             "label": "publish",
             "command": "dotnet",
             "type": "process",

--- a/samples/dotnetcore/App.csproj
+++ b/samples/dotnetcore/App.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="0.3.0-preview01" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Dapr.AspNetCore" Version="0.4.0-preview01" />
   </ItemGroup>
 
 </Project>

--- a/samples/dotnetcore/Controllers/AccountsController.cs
+++ b/samples/dotnetcore/Controllers/AccountsController.cs
@@ -10,8 +10,10 @@ namespace App
     [ApiController]
     public class AccountsController : ControllerBase
     {
+        private const string StateStore = "statestore";
+
         [HttpGet("{account}")]
-        public ActionResult<int> GetBalance(StateEntry<int?> account)
+        public ActionResult<int> GetBalance([FromState(StateStore)] StateEntry<int?> account)
         {
             if (account.Value is null)
             {
@@ -22,7 +24,7 @@ namespace App
         }
 
         [HttpPost("{account}/deposit")]
-        public async Task<ActionResult<int>> Deposit([FromRoute] StateEntry<int?> account, [FromBody] int amount)
+        public async Task<ActionResult<int>> Deposit([FromState(StateStore)] [FromRoute] StateEntry<int?> account, [FromBody] int amount)
         {
             account.Value ??= 0;
             account.Value += amount;
@@ -33,7 +35,7 @@ namespace App
         }
 
         [HttpPost("{account}/withdraw")]
-        public async Task<ActionResult<int>> Withdraw([FromRoute] StateEntry<int?> account, [FromBody] int amount)
+        public async Task<ActionResult<int>> Withdraw([FromState(StateStore)] [FromRoute] StateEntry<int?> account, [FromBody] int amount)
         {
             account.Value ??= 0;
             account.Value -= amount;
@@ -47,7 +49,7 @@ namespace App
         [HttpPost("transaction")]
         public async Task<ActionResult<int>> Transaction(Transaction transaction, [FromServices] StateClient stateClient)
         {
-            var account = await stateClient.GetStateEntryAsync<int?>(transaction.AccountId);
+            var account = await stateClient.GetStateEntryAsync<int?>(StateStore, transaction.AccountId);
 
             switch (transaction.Type)
             {

--- a/src/scaffolding/daprComponentScaffolder.ts
+++ b/src/scaffolding/daprComponentScaffolder.ts
@@ -15,9 +15,9 @@ export async function scaffoldRedisComponent(name: string, folderPath: string, f
 }
 
 export function scaffoldPubSubComponent(folderPath: string, options?: { fileName?: string; redisHost?: string }): Promise<void> {
-    return scaffoldRedisComponent('components/pub-sub.yaml', folderPath, options?.fileName ?? 'redis_messagebus.yaml', options?.redisHost);
+    return scaffoldRedisComponent('components/pub-sub.yaml', folderPath, options?.fileName ?? 'messagebus.yaml', options?.redisHost);
 }
 
 export function scaffoldStateStoreComponent(folderPath: string, options?: { fileName?: string; redisHost?: string }): Promise<void> {
-    return scaffoldRedisComponent('components/state-store.yaml', folderPath, options?.fileName ?? 'redis.yaml', options?.redisHost);
+    return scaffoldRedisComponent('components/state-store.yaml', folderPath, options?.fileName ?? 'statestore.yaml', options?.redisHost);
 }


### PR DESCRIPTION
Dapr 0.4.0 had several breaking issues, so the scaffolding and sample project needed corresponding updates.

 - Update to the latest 0.4.0 version of the SDK
 - Updated to .NET Core 3.1 (required by the SDK)
 - Update the Dapr component scaffolding to conform to the new naming scheme and content.

Resolves #17.