### PR TITLE
CI tweaks

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -11,8 +11,8 @@ jobs:
     vmImage: ubuntu-latest
   steps:
   - template: common/setup.yml
-  - template: common/publish-vsix.yml # Only publish vsix from linux build since we use this to release and want to stay consistent
   - template: common/governance.yml
+  - template: common/publish-vsix.yml # Only publish vsix from linux build since we use this to release and want to stay consistent
 
 - job: macOS
   pool:

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,9 @@
+.azure-pipelines
+.eslintignore
 .vscode/**
 .vscode-test/**
 out/test/**
+samples/**
 src/**
 .gitignore
 vsc-extension-quickstart.md


### PR DESCRIPTION
A couple of CI tweaks:

 - Moves the Corporate Governance task before the build/test/package tasks as it otherwise generates false-positives by confusing content in the `.vscode-test` output folder as old NPM packages.
 - Excludes some extraneous content from the generated VSIX.