### PR TITLE
Force CG before test on non-Linux platforms.

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -4,6 +4,7 @@ jobs:
     vmImage: windows-latest
   steps:
   - template: common/setup.yml
+  - template: common/governance.yml   # Force governance before test to avoid false-positives.
   - template: common/build.yml
 
 - job: Linux
@@ -11,7 +12,7 @@ jobs:
     vmImage: ubuntu-latest
   steps:
   - template: common/setup.yml
-  - template: common/governance.yml
+  - template: common/governance.yml   # Force governance before test to avoid false-positives.
   - template: common/publish-vsix.yml # Only publish vsix from linux build since we use this to release and want to stay consistent
 
 - job: macOS
@@ -19,4 +20,5 @@ jobs:
     vmImage: macOS-latest
   steps:
   - template: common/setup.yml
+  - template: common/governance.yml   # Force governance before test to avoid false-positives.
   - template: common/build.yml


### PR DESCRIPTION
Azure DevOps injects Corporate Governance tasks into the CI process for all platforms (when we only really care about the Linux build for packaging purposes). It gets injected post-build, which then generates false-positives that we already fixed for the Linux platform.  This change forces the CG task to be run before build/test on the other platforms as well.