### PR TITLE
Resolve application monitoring on Windows

### DIFF
--- a/src/commands/applications/invokeCommon.ts
+++ b/src/commands/applications/invokeCommon.ts
@@ -109,7 +109,7 @@ export async function invoke(context: IActionContext, daprApplicationProvider: D
                 ? await daprClient.invokePost(result.application, result.method, result.payload, token)
                 : await daprClient.invokeGet(result.application, result.method, token);
     
-            outputChannel.appendLine(localize('commands.invokeCommon.invokeSucceededMessage', 'Method succeeded: {0}', String(data)));
+            outputChannel.appendLine(localize('commands.invokeCommon.invokeSucceededMessage', 'Method succeeded: {0}', JSON.stringify(data)));
 
             outputChannel.show();
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,7 +64,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			
 			registerDisposable(vscode.tasks.registerTaskProvider('dapr', new DaprCommandTaskProvider(telemetryProvider)));
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd', new DaprdCommandTaskProvider(telemetryProvider)));
-			registerDisposable(vscode.tasks.registerTaskProvider('daprd-down', new DaprdDownTaskProvider(telemetryProvider)));
+			registerDisposable(vscode.tasks.registerTaskProvider('daprd-down', new DaprdDownTaskProvider(daprApplicationProvider, telemetryProvider)));
 			
 			registerDisposable(
 				vscode.window.registerTreeDataProvider(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import createReadDocumentationCommand from './commands/help/readDocumentation';
 import createReportIssueCommand from './commands/help/reportIssue';
 import createReviewIssuesCommand from './commands/help/reviewIssues';
 import createGetStartedCommand from './commands/help/getStarted';
+import createPlatformProcessProvider from './services/processProvider';
 
 export function activate(context: vscode.ExtensionContext): Promise<void> {
 	function registerDisposable<T extends vscode.Disposable>(disposable: T): T {
@@ -48,7 +49,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 
 			initializeTemplateScaffolder(context.extensionPath);
 			
-			const daprApplicationProvider = registerDisposable(new ProcessBasedDaprApplicationProvider());
+			const daprApplicationProvider = registerDisposable(new ProcessBasedDaprApplicationProvider(createPlatformProcessProvider()));
 			const daprClient = new HttpDaprClient(new AxiosHttpClient());
 			const ui = new AggregateUserInput(ext.ui);
 			

--- a/src/services/daprApplicationProvider.ts
+++ b/src/services/daprApplicationProvider.ts
@@ -4,6 +4,7 @@
 import * as psList from 'ps-list';
 import * as vscode from 'vscode';
 import Timer from '../util/timer';
+import { ProcessProvider } from './processProvider';
 
 export interface DaprApplication {
     appId: string;
@@ -59,7 +60,7 @@ export default class ProcessBasedDaprApplicationProvider extends vscode.Disposab
     private readonly onDidChangeEmitter = new vscode.EventEmitter<void>();
     private readonly timer: vscode.Disposable;
 
-    constructor() {
+    constructor(private readonly processProvider: ProcessProvider) {
         super(() => {
             this.timer.dispose();
             this.onDidChangeEmitter.dispose();
@@ -96,10 +97,9 @@ export default class ProcessBasedDaprApplicationProvider extends vscode.Disposab
     }
 
     private async onRefresh(): Promise<void> {
-        const processes = await psList();
-        const daprdProcesses = processes.filter(p => p.name === 'daprd');
+        const processes = await this.processProvider.listProcesses('daprd');
         
-        this.applications = daprdProcesses
+        this.applications = processes
             .map(process => toApplication(process.cmd))
             .filter((application): application is DaprApplication => application !== undefined);
         

--- a/src/services/daprApplicationProvider.ts
+++ b/src/services/daprApplicationProvider.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as psList from 'ps-list';
 import * as vscode from 'vscode';
 import Timer from '../util/timer';
 import { ProcessProvider } from './processProvider';

--- a/src/services/processProvider.ts
+++ b/src/services/processProvider.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as psList from 'ps-list';
+import * as os from 'os';
+import * as sysinfo from 'systeminformation';
+import { Process } from '../util/process';
+
+export interface ProcessInfo {
+    cmd: string;
+    name: string;
+    pid: number;
+}
+
+export interface ProcessProvider {
+    listProcesses(name: string): Promise<ProcessInfo[]>;
+}
+
+export class UnixProcessProvider implements ProcessProvider {
+    async listProcesses(name: string): Promise<ProcessInfo[]> {
+        const processes = await psList();
+
+        return processes
+            .filter(process => process.name === name)
+            .map(process => ({ name: process.name, cmd: process.cmd ?? '', pid: process.pid }));
+    }
+}
+
+function getWmicValue(line: string): string {
+    const index = line.indexOf('=');
+
+    return line.substring(index + 1);
+}
+
+export class WindowsProcessProvider implements ProcessProvider {
+    async listProcesses(name: string): Promise<ProcessInfo[]> {
+        const list = await Process.exec(`wmic process where "name='${name}.exe'" get commandline,name,processid /format:list`);
+        
+        // Lines in the output are delimited by "<CR><CR><LF>".
+        const lines = list.stdout.split('\r\r\n');
+
+        const processes: ProcessInfo[] = [];
+
+        // Each item in the list is prefixed by two empty lines, then <property>=<value> lines, in alphabetical order.
+        for (let i = 0; i < lines.length / 5; i++) {
+            const obj = {};
+
+            // Stop if the input is truncated (as there is an upper output limit)...
+            if ((i * 5) + 4 >= lines.length) {
+                break;
+            }
+
+            const cmd = getWmicValue(lines[(i * 5) + 2]);
+            const name = getWmicValue(lines[(i * 5) + 3]);
+            const pid = parseInt(getWmicValue(lines[(i * 5) + 4]), 10);
+
+            processes.push({ cmd, name, pid });
+        }
+
+        return processes;
+    }
+}
+
+export default function createPlatformProcessProvider(): ProcessProvider {
+    if (os.platform() === 'win32') {
+        return new WindowsProcessProvider();
+    } else {
+        return new UnixProcessProvider();
+    }
+}

--- a/src/services/processProvider.ts
+++ b/src/services/processProvider.ts
@@ -42,8 +42,6 @@ export class WindowsProcessProvider implements ProcessProvider {
 
         // Each item in the list is prefixed by two empty lines, then <property>=<value> lines, in alphabetical order.
         for (let i = 0; i < lines.length / 5; i++) {
-            const obj = {};
-
             // Stop if the input is truncated (as there is an upper output limit)...
             if ((i * 5) + 4 >= lines.length) {
                 break;

--- a/src/services/processProvider.ts
+++ b/src/services/processProvider.ts
@@ -3,7 +3,6 @@
 
 import * as psList from 'ps-list';
 import * as os from 'os';
-import * as sysinfo from 'systeminformation';
 import { Process } from '../util/process';
 
 export interface ProcessInfo {

--- a/src/tasks/daprdDownTaskProvider.ts
+++ b/src/tasks/daprdDownTaskProvider.ts
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as psList from 'ps-list';
 import CustomExecutionTaskProvider from "./customExecutionTaskProvider";
 import { TaskDefinition } from './taskDefinition';
 import { localize } from '../util/localize';
 import { TelemetryProvider } from '../services/telemetryProvider';
-import { ProcessProvider } from '../services/processProvider';
 import { DaprApplicationProvider } from '../services/daprApplicationProvider';
 
 export interface DaprdDownTaskDefinition extends TaskDefinition {

--- a/src/tasks/daprdDownTaskProvider.ts
+++ b/src/tasks/daprdDownTaskProvider.ts
@@ -6,6 +6,8 @@ import CustomExecutionTaskProvider from "./customExecutionTaskProvider";
 import { TaskDefinition } from './taskDefinition';
 import { localize } from '../util/localize';
 import { TelemetryProvider } from '../services/telemetryProvider';
+import { ProcessProvider } from '../services/processProvider';
+import { DaprApplicationProvider } from '../services/daprApplicationProvider';
 
 export interface DaprdDownTaskDefinition extends TaskDefinition {
     appId?: string;
@@ -13,7 +15,7 @@ export interface DaprdDownTaskDefinition extends TaskDefinition {
 }
 
 export default class DaprdDownTaskProvider extends CustomExecutionTaskProvider {
-    constructor(telemetryProvider: TelemetryProvider) {
+    constructor(daprApplicationProvider: DaprApplicationProvider, telemetryProvider: TelemetryProvider) {
         super(
             (definition, writer) => {
                 return telemetryProvider.callWithTelemetry(
@@ -25,14 +27,11 @@ export default class DaprdDownTaskProvider extends CustomExecutionTaskProvider {
                             throw new Error(localize('tasks.daprdDownTaskProvider.appIdError', 'The \'appId\' property must be set.'));
                         }
                         
-                        const processes = await psList();
-                        const daprdProcesses = processes.filter(p => p.name === 'daprd');
-                        
-                        const argumentPattern = `--dapr-id ${daprdDownDefinition.appId}`;
-                        
-                        const appProcesses = daprdProcesses.filter(p => p.cmd?.includes(argumentPattern));
-                        
-                        appProcesses.forEach(p => process.kill(p.pid, 'SIGKILL'));
+                        const applications = await daprApplicationProvider.getApplications();
+
+                        applications
+                            .filter(application => application.appId === daprdDownDefinition.appId)
+                            .forEach(application => process.kill(application.pid, 'SIGKILL'));
                         
                         writer.writeLine(localize('tasks.daprdDownTaskProvider.shutdownMessage', 'Shutting down daprd...'));
                     });


### PR DESCRIPTION
The `ps-list` library used to monitor running `daprd` processes does not provide the command line when used on Windows and, with other process-level differences between the platforms, we are unable to properly detect Dapr applications nor shut them down.  We now use the `wmic` command on Windows to pull that information.

Resolves #42.