### PR TITLE
Add top-level publish message command

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 	"activationEvents": [
 		"onCommand:vscode-dapr.applications.invoke-get",
 		"onCommand:vscode-dapr.applications.invoke-post",
+		"onCommand:vscode-dapr.applications.publish-all-message",
 		"onCommand:vscode-dapr.applications.publish-message",
 		"onCommand:vscode-dapr.help.getStarted",
 		"onCommand:vscode-dapr.help.readDocumentation",
@@ -57,10 +58,15 @@
 				"category": "Dapr"
 			},
 			{
-				"command": "vscode-dapr.applications.publish-message",
-				"title": "%vscode-dapr.applications.publish-message.title%",
+				"command": "vscode-dapr.applications.publish-all-message",
+				"title": "%vscode-dapr.applications.publish-all-message.title%",
 				"category": "Dapr",
 				"icon": "$(radio-tower)"
+			},
+			{
+				"command": "vscode-dapr.applications.publish-message",
+				"title": "%vscode-dapr.applications.publish-message.title%",
+				"category": "Dapr"
 			},
 			{
 				"command": "vscode-dapr.help.getStarted",
@@ -105,7 +111,7 @@
 			],
 			"view/title": [
 				{
-					"command": "vscode-dapr.applications.publish-message",
+					"command": "vscode-dapr.applications.publish-all-message",
 					"group": "navigation"
 				}
 			]

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
 			{
 				"command": "vscode-dapr.applications.publish-message",
 				"title": "%vscode-dapr.applications.publish-message.title%",
-				"category": "Dapr"
+				"category": "Dapr",
+				"icon": "$(radio-tower)"
 			},
 			{
 				"command": "vscode-dapr.help.getStarted",
@@ -100,6 +101,12 @@
 				{
 					"command": "vscode-dapr.applications.publish-message",
 					"when": "view == vscode-dapr.views.applications && viewItem == application"
+				}
+			],
+			"view/title": [
+				{
+					"command": "vscode-dapr.applications.publish-message",
+					"group": "navigation"
 				}
 			]
 		},

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,6 +2,7 @@
     "vscode-dapr.applications.invoke-get.title": "Invoke (GET) Application Method",
     "vscode-dapr.applications.invoke-post.title": "Invoke (POST) Application Method",
     "vscode-dapr.applications.publish-message.title": "Publish Message to Application",
+    "vscode-dapr.applications.publish-all-message.title": "Publish Message to Applications",
     "vscode-dapr.help.readDocumentation.title": "Read Documentation",
     "vscode-dapr.help.getStarted.title": "Get Started",
     "vscode-dapr.help.reportIssue.title": "Report Issue",

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,7 +2,7 @@
     "vscode-dapr.applications.invoke-get.title": "Invoke (GET) Application Method",
     "vscode-dapr.applications.invoke-post.title": "Invoke (POST) Application Method",
     "vscode-dapr.applications.publish-message.title": "Publish Message to Application",
-    "vscode-dapr.applications.publish-all-message.title": "Publish Message to Applications",
+    "vscode-dapr.applications.publish-all-message.title": "Publish Message to All Applications",
     "vscode-dapr.help.readDocumentation.title": "Read Documentation",
     "vscode-dapr.help.getStarted.title": "Get Started",
     "vscode-dapr.help.reportIssue.title": "Report Issue",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import DaprApplicationTreeDataProvider from './views/applications/daprApplicatio
 import ProcessBasedDaprApplicationProvider from './services/daprApplicationProvider';
 import createInvokeGetCommand from './commands/applications/invokeGet';
 import createInvokePostCommand from './commands/applications/invokePost';
-import createPublishMessageCommand from './commands/applications/publishMessage';
+import { createPublishAllMessageCommand, createPublishMessageCommand } from './commands/applications/publishMessage';
 import AxiosHttpClient from './services/httpClient';
 import { AggregateUserInput } from './services/userInput';
 import HttpDaprClient from './services/daprClient';
@@ -55,6 +55,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.invoke-get', createInvokeGetCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.invoke-post', createInvokePostCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));
+			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.publish-all-message', createPublishAllMessageCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.publish-message', createPublishMessageCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.help.readDocumentation', createReadDocumentationCommand(ui));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.help.getStarted', createGetStartedCommand(ui));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.invoke-get', createInvokeGetCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.invoke-post', createInvokePostCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));
-			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.publish-all-message', createPublishAllMessageCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));
+			telemetryProvider.registerCommandWithTelemetry('vscode-dapr.applications.publish-all-message', createPublishAllMessageCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.publish-message', createPublishMessageCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.help.readDocumentation', createReadDocumentationCommand(ui));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.help.getStarted', createGetStartedCommand(ui));


### PR DESCRIPTION
Adds a top-level publish message to all applications command to the Dapr applications tree view.  This command is similar in function to the command exposed on the context menus of individual applications, but is intended to publish to *all* running Dapr applications.

> Currently publishing to "individual" Dapr applications effectively publishes to all, but that behavior is set to change in upcoming Dapr runtime releases.

<img width="292" alt="Screen Shot 2020-03-04 at 2 23 34 PM" src="https://user-images.githubusercontent.com/6402946/75928750-e78f0e80-5e23-11ea-96f5-289d74a04463.png">

Resolves #26.