### PR TITLE
More specific messages for dapr installation issues

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 
 const ignoreBundle = !/^(false|0)?$/i.test(process.env.VSCODE_DAPR_IGNORE_BUNDLE || '');
-const extensionPath = ignoreBundle ? "./out/src/extension" : "./dist/extension";
+const extensionPath = ignoreBundle ? "./out/extension" : "./dist/extension";
 const extension = require(extensionPath);
 
 function activate(ctx) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import createReportIssueCommand from './commands/help/reportIssue';
 import createReviewIssuesCommand from './commands/help/reviewIssues';
 import createGetStartedCommand from './commands/help/getStarted';
 import createPlatformProcessProvider from './services/processProvider';
+import LocalDaprInstallationManager from './services/daprInstallationManager';
 
 export function activate(context: vscode.ExtensionContext): Promise<void> {
 	function registerDisposable<T extends vscode.Disposable>(disposable: T): T {
@@ -70,7 +71,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			registerDisposable(
 				vscode.window.registerTreeDataProvider(
 					'vscode-dapr.views.applications',
-					registerDisposable(new DaprApplicationTreeDataProvider(daprApplicationProvider))));
+					registerDisposable(new DaprApplicationTreeDataProvider(daprApplicationProvider, new LocalDaprInstallationManager()))));
 
 			registerDisposable(
 				vscode.window.registerTreeDataProvider(

--- a/src/services/daprInstallationManager.ts
+++ b/src/services/daprInstallationManager.ts
@@ -1,0 +1,19 @@
+export interface DaprVersion {
+    cli: string;
+    runtime: string;
+}
+
+export interface DaprInstallationManager {
+    getVersion(): Promise<DaprVersion | undefined>;
+    isInitialized(): Promise<boolean>;
+}
+
+export default class LocalDaprInstallationManager implements DaprInstallationManager {
+    getVersion(): Promise<DaprVersion | undefined> {
+        return Promise.resolve(undefined);
+    }
+
+    isInitialized(): Promise<boolean> {
+        return Promise.resolve(false);
+    }
+}

--- a/src/services/daprInstallationManager.ts
+++ b/src/services/daprInstallationManager.ts
@@ -47,10 +47,10 @@ export default class LocalDaprInstallationManager implements DaprInstallationMan
 
         this.initialized = new AsyncLazy<boolean>(
             async () => {
-                const psResults = await Process.exec('docker ps --format "{{json .}}"');
+                const psResult = await Process.exec('docker ps --format "{{json .}}"');
 
-                if (psResults.code === 0) {
-                    const lines = psResults.stdout.split('\n');
+                if (psResult.code === 0) {
+                    const lines = psResult.stdout.split('\n');
                     const containers = lines.map(line => JSON.parse(line));
                     const daprContainers = containers.filter(container => container.Image === 'daprio/dapr');
 

--- a/src/util/lazy.ts
+++ b/src/util/lazy.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export class Lazy<T> {
+    private _value: T | undefined;
+
+    constructor(private readonly factory: () => T | undefined) {
+    }
+
+    get hasValue(): boolean {
+        return this._value !== undefined;
+    }
+
+    get value(): T | undefined {
+        if (this._value === undefined) {
+            this._value = this.factory();
+        }
+
+        return this._value;
+    }
+}
+
+export class AsyncLazy<T> {
+    private _value: T | undefined;
+
+    constructor(private readonly factory: () => Promise<T | undefined>) {
+    }
+
+    get hasValue(): boolean {
+        return this._value !== undefined;
+    }
+
+    async getValue(): Promise<T | undefined> {
+        if (this._value === undefined) {
+            this._value = await this.factory();
+        }
+
+        return this._value;
+    }
+}

--- a/src/views/applications/daprApplicationTreeDataProvider.ts
+++ b/src/views/applications/daprApplicationTreeDataProvider.ts
@@ -6,12 +6,15 @@ import { DaprApplicationProvider } from '../../services/daprApplicationProvider'
 import TreeNode from '../treeNode';
 import DaprApplicationNode from './daprApplicationNode';
 import NoApplicationsRunningNode from './noApplicationsRunningNode';
+import { DaprInstallationManager } from '../../services/daprInstallationManager';
 
 export default class DaprApplicationTreeDataProvider extends vscode.Disposable implements vscode.TreeDataProvider<TreeNode> {
     private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<TreeNode | null | undefined>();
     private readonly applicationProviderListener: vscode.Disposable;
 
-    constructor(private readonly applicationProvider: DaprApplicationProvider) {
+    constructor(
+        private readonly applicationProvider: DaprApplicationProvider,
+        private readonly installationManager: DaprInstallationManager) {
         super(() => {
             this.applicationProviderListener.dispose();
             this.onDidChangeTreeDataEmitter.dispose();
@@ -37,7 +40,7 @@ export default class DaprApplicationTreeDataProvider extends vscode.Disposable i
         if (applications.length > 0) {
             return applications.map(application => new DaprApplicationNode(application));
         } else {
-            return [ new NoApplicationsRunningNode() ];
+            return [ new NoApplicationsRunningNode(this.installationManager) ];
         }
     }
 }

--- a/src/views/applications/noApplicationsRunningNode.ts
+++ b/src/views/applications/noApplicationsRunningNode.ts
@@ -11,12 +11,12 @@ export default class NoApplicationsRunningNode implements TreeNode {
     }
 
     async getTreeItem(): Promise<vscode.TreeItem> {
-        let label = localize('views.noApplicationsRunningNode.notInstalledLabel', 'Dapr is not installed.');
+        let label = localize('views.noApplicationsRunningNode.notInstalledLabel', 'The Dapr CLI and runtime do not appear to be installed.');
 
         const version = await this.installationManager.getVersion();
         
         if (version && version.cli) {
-            label = localize('views.noApplicationsRunningNode.notInitializedLabel', 'Dapr is not initialized.');
+            label = localize('views.noApplicationsRunningNode.notInitializedLabel', 'The Dapr runtime does not appear to be initialized.');
 
             const isInitialized = await this.installationManager.isInitialized();
 

--- a/src/views/applications/noApplicationsRunningNode.ts
+++ b/src/views/applications/noApplicationsRunningNode.ts
@@ -21,7 +21,7 @@ export default class NoApplicationsRunningNode implements TreeNode {
             const isInitialized = await this.installationManager.isInitialized();
 
             if (isInitialized) {
-                localize('views.noApplicationsRunningNode.label', 'No Dapr applications are running.')
+                label = localize('views.noApplicationsRunningNode.label', 'No Dapr applications are running.')
             }
         }
 

--- a/src/views/applications/noApplicationsRunningNode.ts
+++ b/src/views/applications/noApplicationsRunningNode.ts
@@ -15,7 +15,7 @@ export default class NoApplicationsRunningNode implements TreeNode {
 
         const version = await this.installationManager.getVersion();
         
-        if (version) {
+        if (version && version.cli) {
             label = localize('views.noApplicationsRunningNode.notInitializedLabel', 'Dapr is not initialized.');
 
             const isInitialized = await this.installationManager.isInitialized();

--- a/src/views/applications/noApplicationsRunningNode.ts
+++ b/src/views/applications/noApplicationsRunningNode.ts
@@ -4,10 +4,28 @@
 import * as vscode from 'vscode';
 import TreeNode from '../treeNode';
 import { localize } from '../../util/localize';
+import { DaprInstallationManager } from '../../services/daprInstallationManager';
 
 export default class NoApplicationsRunningNode implements TreeNode {
-    getTreeItem(): Promise<vscode.TreeItem> {
-        const treeItem = new vscode.TreeItem(localize('views.noApplicationsRunningNode.label', 'No Dapr applications are running.'));
+    constructor(private readonly installationManager: DaprInstallationManager) {
+    }
+
+    async getTreeItem(): Promise<vscode.TreeItem> {
+        let label = localize('views.noApplicationsRunningNode.notInstalledLabel', 'Dapr is not installed.');
+
+        const version = await this.installationManager.getVersion();
+        
+        if (version) {
+            label = localize('views.noApplicationsRunningNode.notInitializedLabel', 'Dapr is not initialized.');
+
+            const isInitialized = await this.installationManager.isInitialized();
+
+            if (isInitialized) {
+                localize('views.noApplicationsRunningNode.label', 'No Dapr applications are running.')
+            }
+        }
+
+        const treeItem = new vscode.TreeItem(label);
 
         treeItem.iconPath = new vscode.ThemeIcon('warning');
 


### PR DESCRIPTION
Currently, if no `daprd` instances are found, the Dapr applications tree view will display "no applications are running".  However, this might be because Dapr (the CLI and/or runtime) have never been installed, or have been installed, but the Dapr runtime has not been initialized.  This change detects those latter conditions and provides a slightly more specific message.

Resolves #46.

<img width="408" alt="Screen Shot 2020-03-09 at 2 27 12 PM" src="https://user-images.githubusercontent.com/6402946/76259524-feae7180-6212-11ea-8471-941de1b0c179.png">
