### PR TITLE
Show error when redirected to HTTPS endpoint

### DIFF
--- a/src/services/daprClient.ts
+++ b/src/services/daprClient.ts
@@ -4,13 +4,32 @@
 import * as url from 'url';
 import * as vscode from 'vscode';
 import { DaprApplication } from "./daprApplicationProvider";
-import { HttpClient } from './httpClient';
+import { HttpClient, HttpResponse } from './httpClient';
 import { localize } from '../util/localize';
 
 export interface DaprClient {
     invokeGet(application: DaprApplication, method: string, token?: vscode.CancellationToken): Promise<unknown>;
     invokePost(application: DaprApplication, method: string, payload?: unknown, token?: vscode.CancellationToken): Promise<unknown>;
     publishMessage(application: DaprApplication, topic: string, payload?: unknown, token?: vscode.CancellationToken): Promise<void>;
+}
+
+function manageResponse(response: HttpResponse): unknown {
+    if (response.status >= 300 && response.status < 400) {
+        const redirectionUrl = response.headers['location'];
+
+        if (redirectionUrl) {
+            const parsedRedirectionUrl = new url.URL(redirectionUrl);
+
+            if (parsedRedirectionUrl.protocol === 'https:'
+                && (parsedRedirectionUrl.hostname === 'localhost' || parsedRedirectionUrl.hostname === '127.0.0.1')) {
+                throw new Error(localize('services.daprClient.httpsRedirectError', 'The application redirected to the local HTTPS endpoint \'{0}\'. This is usually a mistake in application configuration. Dapr expects to invoke the application via HTTP.', redirectionUrl));
+            }
+        }
+        
+        return localize('services.daprClient.redirectionResponse', '{0} Redirected to \'{1}\'', response.status, redirectionUrl);
+    }
+
+    return response.data;
 }
 
 export default class HttpDaprClient implements DaprClient {
@@ -22,30 +41,15 @@ export default class HttpDaprClient implements DaprClient {
 
         const response = await this.httpClient.get(originalUrl, { allowRedirects: false }, token);
 
-        if (response.status >= 300 && response.status < 400) {
-            const redirectionUrl = response.headers['location'];
-
-            if (redirectionUrl) {
-                const parsedRedirectionUrl = new url.URL(redirectionUrl);
-
-                if (parsedRedirectionUrl.protocol === 'https:'
-                    && (parsedRedirectionUrl.hostname === 'localhost' || parsedRedirectionUrl.hostname === '127.0.0.1')) {
-                    throw new Error(localize('services.daprClient.httpsRedirectError', 'The application redirected to the local HTTPS endpoint \'{0}\'. This is usually a mistake in application configuration. Dapr expects to invoke the application via HTTP.', redirectionUrl));
-                }
-            }
-            
-            return localize('services.daprClient.redirectionResponse', '{0} Redirected to \'{1}\'', response.status, redirectionUrl);
-        }
-
-        return response.data;
+        return manageResponse(response);
     }
 
     async invokePost(application: DaprApplication, method: string, payload?: unknown, token?: vscode.CancellationToken | undefined): Promise<unknown> {
         const url = `http://localhost:${application.httpPort}/v1.0/invoke/${application.appId}/method/${method}`;
 
-        const response = await this.httpClient.post(url, payload, { json: true }, token);
+        const response = await this.httpClient.post(url, payload, { allowRedirects: false, json: true }, token);
 
-        return response.data;
+        return manageResponse(response);
     }
 
     async publishMessage(application: DaprApplication, topic: string, payload?: unknown, token?: vscode.CancellationToken): Promise<void> {

--- a/src/services/daprClient.ts
+++ b/src/services/daprClient.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as url from 'url';
 import * as vscode from 'vscode';
 import { DaprApplication } from "./daprApplicationProvider";
 import { HttpClient } from './httpClient';
+import { localize } from '../util/localize';
 
 export interface DaprClient {
     invokeGet(application: DaprApplication, method: string, token?: vscode.CancellationToken): Promise<unknown>;
@@ -16,9 +18,24 @@ export default class HttpDaprClient implements DaprClient {
     }
 
     async invokeGet(application: DaprApplication, method: string, token?: vscode.CancellationToken | undefined): Promise<unknown> {
-        const url = `http://localhost:${application.httpPort}/v1.0/invoke/${application.appId}/method/${method}`;
+        const originalUrl = `http://localhost:${application.httpPort}/v1.0/invoke/${application.appId}/method/${method}`;
 
-        const response = await this.httpClient.get(url, token);
+        const response = await this.httpClient.get(originalUrl, { allowRedirects: false }, token);
+
+        if (response.status >= 300 && response.status < 400) {
+            const redirectionUrl = response.headers['location'];
+
+            if (redirectionUrl) {
+                const parsedRedirectionUrl = new url.URL(redirectionUrl);
+
+                if (parsedRedirectionUrl.protocol === 'https:'
+                    && (parsedRedirectionUrl.hostname === 'localhost' || parsedRedirectionUrl.hostname === '127.0.0.1')) {
+                    throw new Error(localize('services.daprClient.httpsRedirectError', 'The application redirected to the local HTTPS endpoint \'{0}\'. This is usually a mistake in application configuration. Dapr expects to invoke the application via HTTP.', redirectionUrl));
+                }
+            }
+            
+            return localize('services.daprClient.redirectionResponse', '{0} Redirected to \'{1}\'', response.status, redirectionUrl);
+        }
 
         return response.data;
     }


### PR DESCRIPTION
Shows an error when the application (during a GET or POST method invocation) redirects to a local HTTPS endpoint (which is most likely to be a configuration error, as Dapr expects calls to be invoked via HTTP). Also now treats all other redirection as the "result" of the invocation rather than following the redirect and returning *that* result.

This addresses (for now) the issue where the users forgets the `--no-https` flag when scaffolding a new .NET Core web application, which otherwise scaffolds a blanket redirection of calls to the HTTP endpoint to the HTTPS endpoint. 

This resolves #44.