### PR TITLE
Adds nuance to default port selection during scaffolding

### DIFF
--- a/src/commands/scaffoldDaprTasks.ts
+++ b/src/commands/scaffoldDaprTasks.ts
@@ -51,6 +51,7 @@ interface ScaffoldWizardContext {
 const DefaultPort = 80;
 const DjangoPort = 8000;
 const FlaskPort = 5000;
+const JavaPort = 8080;
 const NetCorePort = 5000;
 const NodePort = 3000;
 
@@ -58,6 +59,9 @@ function getDefaultPort(configuration: vscode.DebugConfiguration | undefined): n
     switch (configuration?.type) {
         case 'coreclr':
             return NetCorePort;
+
+        case 'java':
+            return JavaPort;
 
         case 'node':
         case 'node2':

--- a/src/commands/scaffoldDaprTasks.ts
+++ b/src/commands/scaffoldDaprTasks.ts
@@ -68,18 +68,22 @@ function getDefaultPort(configuration: vscode.DebugConfiguration | undefined): n
             return NodePort;
 
         case 'python':
+            // "module": "flask" is a primary indicator of a Flask application...
             if (configuration?.module === 'flask') {
                 return FlaskPort;
             }
 
+            // "django": true is a primary indicator of a Django application...
             if (configuration?.django === true) {
                 return DjangoPort;
             }
 
+            // "jinja": true is a secondary indicator of a Flask application...
             if (configuration?.jinja === true) {
                 return FlaskPort;
             }
 
+            // Django seems to have a slight edge over Flask in popularity, so default to that...
             return DjangoPort;
     }
 


### PR DESCRIPTION
When scaffolding Dapr tasks, adds some nuance to the default port shown to the user for Python and Java applications.  For Python, if the existing debug launch configuration appears to be for a Flask application, port 5000 will be the default. Otherwise, if the configuration appears to be for a Django application (or if unable to determine the type), port 8000 will be the default.  For Java, the default port is 8080 (used by most Java web frameworks).

Resolves #54.
Resolves #55.