### PR TITLE
Updates for 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Change Log
 
+## v0.2.0 - 18 March 2020
+
+Further updates related to the Dapr 0.5.0 release.
+
+### Added
+
+* Bundle extension assets for size/performance. [#16](https://github.com/microsoft/vscode-dapr/issues/16)
+* Expose publish command at tree view level. [#26](https://github.com/microsoft/vscode-dapr/issues/26)
+* Detect when Dapr is not installed or initialized. [#46](https://github.com/microsoft/vscode-dapr/issues/46)
+
+### Updated
+
+* Add smarter default for Python ports. [#54](https://github.com/microsoft/vscode-dapr/issues/54)
+* Add smarter defaults for Java ports. [#55](https://github.com/microsoft/vscode-dapr/issues/55)
+* Add support for new `daprd` 0.5.0 arguments. [#69](https://github.com/microsoft/vscode-dapr/issues/69)
+
+### Fixed
+
+* Make Dapr invocation work with .NET Core ASP.NET using SSL. [#44](https://github.com/microsoft/vscode-dapr/issues/44)
+
 ## v0.1.1 - 12 March 2020
 
 Minor update for the Dapr 0.5.0 release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Further updates related to the Dapr 0.5.0 release.
 
 * Bundle extension assets for size/performance. [#16](https://github.com/microsoft/vscode-dapr/issues/16)
 * Expose publish command at tree view level. [#26](https://github.com/microsoft/vscode-dapr/issues/26)
+* Manage conflicts during scaffolding. [#33](https://github.com/microsoft/vscode-dapr/issues/33)
 * Detect when Dapr is not installed or initialized. [#46](https://github.com/microsoft/vscode-dapr/issues/46)
 
 ### Updated

--- a/NOTICE.html
+++ b/NOTICE.html
@@ -1,6 +1,6 @@
 <!doctype html><html lang="en"><head><title>NOTICES AND INFORMATION</title><style>pre{white-space:pre-wrap;background:#eee;padding:24px}</style></head><body><h1>NOTICES AND INFORMATION</h1><h2>Do Not Translate or Localize</h2><p>This software incorporates material from third parties. Microsoft makes certain open source code available at <a href="https://3rdpartysource.microsoft.com">https://3rdpartysource.microsoft.com</a>, or you may send a check or money order for US $5.00, including the product name, the open source component name, platform, and version number, to:</p><address>Source Code Compliance Team<br>Microsoft Corporation<br>One Microsoft Way<br>Redmond, WA 98052<br>USA</address><p>Notwithstanding any other terms, you may reverse engineer this software to the extent required to debug changes to any libraries licensed under the GNU Lesser General Public License.</p><ol><li><details><summary>adal-node 0.1.28 - Apache-2.0</summary><p><a href="https://github.com/AzureAD/azure-activedirectory-library-for-nodejs#readme">https://github.com/AzureAD/azure-activedirectory-library-for-nodejs#readme</a></p><ul><li>Copyright (c) Microsoft Open Technologies, Inc.</li></ul><pre>﻿                                 Apache License
-    Version 2.0, January 2004
- http://www.apache.org/licenses/
+   Version 2.0, January 2004
+http://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -281,8 +281,8 @@ If the Work includes a &quot;NOTICE&quot; text file as part of its distribution,
 8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
 9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
 END OF TERMS AND CONDITIONS</pre></details></li><li><details><summary>ecdsa-sig-formatter 1.0.11 - Apache-2.0</summary><p><a href="https://github.com/Brightspace/node-ecdsa-sig-formatter#readme">https://github.com/Brightspace/node-ecdsa-sig-formatter#readme</a></p><ul><li>Copyright 2015 D2L Corporation</li></ul><pre>Apache License
-    Version 2.0, January 2004
- http://www.apache.org/licenses/
+   Version 2.0, January 2004
+http://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -766,7 +766,7 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</pre></details></li><li><details><summary>domelementtype 2.0.1 - BSD-2-Clause</summary><p><a href="https://github.com/fb55/domelementtype#readme">https://github.com/fb55/domelementtype#readme</a></p><ul><li>Copyright (c) Felix Bohm</li></ul><pre>Copyright (c) Felix Böhm
+</pre></details></li><li><details><summary>domelementtype 1.3.1 - BSD-2-Clause</summary><p><a href="https://github.com/fb55/domelementtype#readme">https://github.com/fb55/domelementtype#readme</a></p><ul><li>Copyright (c) Felix Bohm</li></ul><pre>Copyright (c) Felix Böhm
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -777,7 +777,7 @@ Redistributions in binary form must reproduce the above copyright notice, this l
 
 THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</pre></details></li><li><details><summary>domelementtype 1.3.1 - BSD-2-Clause</summary><p><a href="https://github.com/fb55/domelementtype#readme">https://github.com/fb55/domelementtype#readme</a></p><ul><li>Copyright (c) Felix Bohm</li></ul><pre>Copyright (c) Felix Böhm
+</pre></details></li><li><details><summary>domelementtype 2.0.1 - BSD-2-Clause</summary><p><a href="https://github.com/fb55/domelementtype#readme">https://github.com/fb55/domelementtype#readme</a></p><ul><li>Copyright (c) Felix Bohm</li></ul><pre>Copyright (c) Felix Böhm
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -818,7 +818,7 @@ Redistribution and use in source and binary forms, with or without modification,
 
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</pre></details></li><li><details><summary>entities 1.1.2 - BSD-2-Clause</summary><p><a href="https://github.com/fb55/entities#readme">https://github.com/fb55/entities#readme</a></p><ul><li>Copyright (c) Felix Bohm</li><li>(c) // http://mathiasbynens.be/notes/javascript-encoding</li></ul><pre>Copyright (c) Felix Böhm
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</pre></details></li><li><details><summary>entities 2.0.0 - BSD-2-Clause</summary><p><a href="https://github.com/fb55/entities#readme">https://github.com/fb55/entities#readme</a></p><pre>Copyright (c) Felix Böhm
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -829,7 +829,7 @@ Redistributions in binary form must reproduce the above copyright notice, this l
 
 THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</pre></details></li><li><details><summary>entities 2.0.0 - BSD-2-Clause</summary><p><a href="https://github.com/fb55/entities#readme">https://github.com/fb55/entities#readme</a></p><pre>Copyright (c) Felix Böhm
+</pre></details></li><li><details><summary>entities 1.1.2 - BSD-2-Clause</summary><p><a href="https://github.com/fb55/entities#readme">https://github.com/fb55/entities#readme</a></p><ul><li>Copyright (c) Felix Bohm</li><li>(c) // http://mathiasbynens.be/notes/javascript-encoding</li></ul><pre>Copyright (c) Felix Böhm
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -1005,7 +1005,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-           *   *   *
+          *   *   *
 
 The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
 </pre></details></li><li><details><summary>source-map 0.6.1 - BSD-3-Clause</summary><p><a href="https://github.com/mozilla/source-map">https://github.com/mozilla/source-map</a></p><ul><li>Copyright 2011 The Closure Compiler</li><li>Copyright 2011 Mozilla Foundation and contributors</li><li>Copyright 2014 Mozilla Foundation and contributors</li><li>Copyright 2009-2011 Mozilla Foundation and contributors</li><li>Copyright (c) 2009-2011, Mozilla Foundation and contributors</li></ul><pre>
@@ -1143,7 +1143,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE
-</pre></details></li><li><details><summary>@types/node 12.12.28 - MIT</summary><ul><li>Copyright (c) Microsoft Corporation.</li></ul><pre>    MIT License
+</pre></details></li><li><details><summary>@types/node 12.12.30 - MIT</summary><ul><li>Copyright (c) Microsoft Corporation.</li></ul><pre>    MIT License
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
@@ -1164,6 +1164,26 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE
+</pre></details></li><li><details><summary>1to2 1.0.0 - MIT</summary><ul><li>Copyright (c) 2014 3VOT</li></ul><pre>The MIT License (MIT)
+
+Copyright (c) 2014 3VOT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the &quot;Software&quot;), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre></details></li><li><details><summary>ajv 6.10.2 - MIT</summary><p><a href="https://github.com/epoberezkin/ajv">https://github.com/epoberezkin/ajv</a></p><ul><li>(c) 2011 Gary Court.</li><li>Copyright 2011 Gary Court.</li><li>Copyright (c) 2015-2017 Evgeny Poberezkin</li></ul><pre>The MIT License (MIT)
 
 Copyright (c) 2015-2017 Evgeny Poberezkin
@@ -1377,6 +1397,28 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+</pre></details></li><li><details><summary>commander 2.20.3 - MIT</summary><p><a href="https://github.com/tj/commander.js#readme">https://github.com/tj/commander.js#readme</a></p><ul><li>Copyright (c) 2011 TJ Holowaychuk &lt;tj@vision-media.ca&gt;</li></ul><pre>(The MIT License)
+
+Copyright (c) 2011 TJ Holowaychuk &lt;tj@vision-media.ca&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+&#x27;Software&#x27;), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &#x27;AS IS&#x27;, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre></details></li><li><details><summary>core-util-is 1.0.2 - MIT</summary><p><a href="https://github.com/isaacs/core-util-is#readme">https://github.com/isaacs/core-util-is#readme</a></p><ul><li>Copyright Joyent, Inc. and other Node contributors.</li></ul><pre>Copyright Node.js contributors. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -1442,9 +1484,9 @@ THE SOFTWARE.
 
 
 
-          Apache License
-    Version 2.0, January 2004
- http://www.apache.org/licenses/
+         Apache License
+   Version 2.0, January 2004
+http://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -1791,7 +1833,37 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</pre></details></li><li><details><summary>extend 3.0.2 - MIT</summary><p><a href="https://github.com/justmoon/node-extend#readme">https://github.com/justmoon/node-extend#readme</a></p><ul><li>Copyright (c) 2014 Stefan Thomas</li></ul><pre>The MIT License (MIT)
+SOFTWARE.</pre></details></li><li><details><summary>escape-string-regexp 2.0.0 - MIT</summary><p><a href="https://github.com/sindresorhus/escape-string-regexp#readme">https://github.com/sindresorhus/escape-string-regexp#readme</a></p><ul><li>(c) Sindre Sorhus (https://sindresorhus.com)</li><li>Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)</li></ul><pre>MIT License
+
+Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre></details></li><li><details><summary>escape-string-regexp 1.0.5 - MIT</summary><p><a href="https://github.com/sindresorhus/escape-string-regexp">https://github.com/sindresorhus/escape-string-regexp</a></p><ul><li>(c) Sindre Sorhus (http://sindresorhus.com)</li><li>Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)</li></ul><pre>The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+</pre></details></li><li><details><summary>extend 3.0.2 - MIT</summary><p><a href="https://github.com/justmoon/node-extend#readme">https://github.com/justmoon/node-extend#readme</a></p><ul><li>Copyright (c) 2014 Stefan Thomas</li></ul><pre>The MIT License (MIT)
 
 Copyright (c) 2014 Stefan Thomas
 
@@ -1912,7 +1984,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-</pre></details></li><li><details><summary>fs-extra 8.1.0 - MIT</summary><p><a href="https://github.com/jprichardson/node-fs-extra">https://github.com/jprichardson/node-fs-extra</a></p><ul><li>Copyright (c) 2011-2017 JP Richardson</li><li>Copyright (c) 2011-2017 JP Richardson (https://github.com/jprichardson)</li><li>Copyright (c) 2014-2016 Jonathan Ong me@jongleberry.com and Contributors</li></ul><pre>(The MIT License)
+</pre></details></li><li><details><summary>fs-extra 4.0.3 - MIT</summary><p><a href="https://github.com/jprichardson/node-fs-extra">https://github.com/jprichardson/node-fs-extra</a></p><ul><li>Copyright (c) 2011-2017 JP Richardson</li><li>Copyright (c) 2011-2017 JP Richardson (https://github.com/jprichardson)</li><li>Copyright (c) 2014-2016 Jonathan Ong me@jongleberry.com and Contributors</li></ul><pre>(The MIT License)
 
 Copyright (c) 2011-2017 JP Richardson
 
@@ -1927,7 +1999,7 @@ THE SOFTWARE IS PROVIDED &#x27;AS IS&#x27;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
 OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre></details></li><li><details><summary>fs-extra 4.0.3 - MIT</summary><p><a href="https://github.com/jprichardson/node-fs-extra">https://github.com/jprichardson/node-fs-extra</a></p><ul><li>Copyright (c) 2011-2017 JP Richardson</li><li>Copyright (c) 2011-2017 JP Richardson (https://github.com/jprichardson)</li><li>Copyright (c) 2014-2016 Jonathan Ong me@jongleberry.com and Contributors</li></ul><pre>(The MIT License)
+</pre></details></li><li><details><summary>fs-extra 8.1.0 - MIT</summary><p><a href="https://github.com/jprichardson/node-fs-extra">https://github.com/jprichardson/node-fs-extra</a></p><ul><li>Copyright (c) 2011-2017 JP Richardson</li><li>Copyright (c) 2011-2017 JP Richardson (https://github.com/jprichardson)</li><li>Copyright (c) 2014-2016 Jonathan Ong me@jongleberry.com and Contributors</li></ul><pre>(The MIT License)
 
 Copyright (c) 2011-2017 JP Richardson
 
@@ -2088,7 +2160,7 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-</pre></details></li><li><details><summary>is-buffer 1.1.6 - MIT</summary><p><a href="https://github.com/feross/is-buffer#readme">https://github.com/feross/is-buffer#readme</a></p><ul><li>Copyright (c) Feross Aboukhadijeh</li><li>Copyright (c) Feross Aboukhadijeh (http://feross.org).</li></ul><pre>The MIT License (MIT)
+</pre></details></li><li><details><summary>is-buffer 2.0.4 - MIT</summary><p><a href="https://github.com/feross/is-buffer#readme">https://github.com/feross/is-buffer#readme</a></p><ul><li>Copyright (c) Feross Aboukhadijeh</li><li>Copyright (c) Feross Aboukhadijeh (http://feross.org).</li></ul><pre>The MIT License (MIT)
 
 Copyright (c) Feross Aboukhadijeh
 
@@ -2109,7 +2181,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-</pre></details></li><li><details><summary>is-buffer 2.0.4 - MIT</summary><p><a href="https://github.com/feross/is-buffer#readme">https://github.com/feross/is-buffer#readme</a></p><ul><li>Copyright (c) Feross Aboukhadijeh</li><li>Copyright (c) Feross Aboukhadijeh (http://feross.org).</li></ul><pre>The MIT License (MIT)
+</pre></details></li><li><details><summary>is-buffer 1.1.6 - MIT</summary><p><a href="https://github.com/feross/is-buffer#readme">https://github.com/feross/is-buffer#readme</a></p><ul><li>Copyright (c) Feross Aboukhadijeh</li><li>Copyright (c) Feross Aboukhadijeh (http://feross.org).</li></ul><pre>The MIT License (MIT)
 
 Copyright (c) Feross Aboukhadijeh
 
@@ -3078,12 +3150,8 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 For more information, please refer to &lt;http://unlicense.org&gt;
-</pre></details></li><li><details><summary>json-schema 0.2.3 - AFL-2.1 OR BSD-3-Clause</summary><p><a href="https://github.com/kriszyp/json-schema#readme">https://github.com/kriszyp/json-schema#readme</a></p><ul><li>Copyright (c) 2007 Kris Zyp SitePen (www.sitepen.com)</li></ul><pre>AFL-2.1 OR BSD-3-Clause</pre></details></li><li><details><summary>xmldom 0.2.1 - MIT OR LGPL-2.0-only</summary><p><a href="https://github.com/xmldom/xmldom">https://github.com/xmldom/xmldom</a></p><pre>You can choose any one of those:
+</pre></details></li><li><details><summary>json-schema 0.2.3 - AFL-2.1 OR BSD-3-Clause</summary><p><a href="https://github.com/kriszyp/json-schema#readme">https://github.com/kriszyp/json-schema#readme</a></p><ul><li>Copyright (c) 2007 Kris Zyp SitePen (www.sitepen.com)</li></ul><pre>AFL-2.1 OR BSD-3-Clause</pre></details></li><li><details><summary>xmldom 0.3.0 - LGPL-2.0 OR MIT OR (LGPL-2.0 AND MIT)</summary><p><a href="https://github.com/xmldom/xmldom">https://github.com/xmldom/xmldom</a></p><pre>You can choose any one of these licenses:
 
-The MIT License (MIT):
-
-link:http://opensource.org/licenses/MIT
-
-LGPL:
-http://www.gnu.org/licenses/lgpl.html
+- MIT: https://opensource.org/licenses/MIT
+- LGPL: http://www.gnu.org/licenses/lgpl.html
 </pre></details></li></ol></body></html>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dapr for Visual Studio Code (Preview)
 
+[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/ms-azuretools.vscode-dapr.svg)](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-dapr)
+[![Marketplace Installs](https://vsmarketplacebadge.apphb.com/installs-short/ms-azuretools.vscode-dapr.svg)](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-dapr)
 [![Build Status](https://dev.azure.com/ms-azuretools/AzCode/_apis/build/status/vscode-dapr-nightly?branchName=master)](https://dev.azure.com/ms-azuretools/AzCode/_build/latest?definitionId=26&branchName=master)
 
 The Dapr extension makes it easy to setup debugging of applications within the Dapr environment as well as interact with applications via the Dapr runtime.
@@ -13,6 +15,8 @@ Local development with Dapr requires a running instance of Docker; follow the [D
 ### Dapr CLI and Runtime
 
 Follow the [Dapr guide](https://dapr.io/#download) to install the Dapr CLI for your platform and initialize the Dapr runtime.
+
+> This extension requires Dapr 0.5.0 or later.
 
 ### Visual Studio Code
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Dapr",
 	"description": "%vscode-dapr.description%",
 	"icon": "assets/images/extensionIcon.png",
-	"version": "0.1.2-alpha",
+	"version": "0.2.0",
 	"preview": true,
 	"publisher": "ms-azuretools",
 	"license": "SEE LICENSE IN LICENSE.txt",


### PR DESCRIPTION
For the pending 0.2.0 release:

 - Bump the version number.
 - Update the README (adding badges and pulling forward changes made from 0.1.1).
 - Update changelog.
 - Update 3rd-party license notice file.