### PR TITLE
Fix description text.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.2.1 - 19 March 2020
+
+Minor fixes.
+
+### Fixed
+
+* "Localized" extension description isn't resolved in Marketplace. [#77](https://github.com/microsoft/vscode-dapr/issues/77)
+
 ## v0.2.0 - 18 March 2020
 
 Further updates related to the Dapr 0.5.0 release.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "vscode-dapr",
 	"displayName": "Dapr",
-	"description": "%vscode-dapr.description%",
+	"description": "Makes it easy to run, debug, and interact with Dapr-enabled applications.",
 	"icon": "assets/images/extensionIcon.png",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"preview": true,
 	"publisher": "ms-azuretools",
 	"license": "SEE LICENSE IN LICENSE.txt",


### PR DESCRIPTION
Fix an ugly bug where the localization text isn't resolved for the extension description by reverting to a non-localized string (until more investigation can be done).