### PR TITLE
"End" dapr problem matcher on wait or initialized.

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
 				],
 				"background": {
 					"beginsPattern": "^.*starting Dapr Runtime",
-					"endsPattern": "^.*waiting on port"
+					"endsPattern": "^.*(waiting on port|dapr initialized)"
 				}
 			}
 		],


### PR DESCRIPTION
"End" the `daprd` task either when it's waiting on the associated web application to start (in order to give the debugger a chance to spin up the application) or when `daprd` is "initialized" (such as when running `daprd` with a console application).

Resolves #89.