### PR TITLE
Scaffold only folder-scoped tasks/configurations.

### DIFF
--- a/src/scaffolding/configurationScaffolder.ts
+++ b/src/scaffolding/configurationScaffolder.ts
@@ -11,14 +11,14 @@ export interface DebugConfiguration extends vscode.DebugConfiguration {
 
 export type ConfigurationContentFactory = (name: string) => DebugConfiguration;
 
-export function getWorkspaceConfigurations(): DebugConfiguration[] {
-    const workspaceConfigurations = vscode.workspace.getConfiguration('launch');
+export function getWorkspaceConfigurations(folder: vscode.WorkspaceFolder): DebugConfiguration[] {
+    const workspaceConfigurations = vscode.workspace.getConfiguration('launch', folder.uri);
     
     return workspaceConfigurations.configurations ?? [];
 }
 
-export default async function scaffoldConfiguration(name: string, contentFactory: ConfigurationContentFactory, onConflict: ConflictHandler): Promise<string | undefined> {
-    const workspaceConfiguration = vscode.workspace.getConfiguration('launch');
+export default async function scaffoldConfiguration(name: string, folder: vscode.WorkspaceFolder, contentFactory: ConfigurationContentFactory, onConflict: ConflictHandler): Promise<string | undefined> {
+    const workspaceConfiguration = vscode.workspace.getConfiguration('launch', folder.uri);
     const workspaceConfigurations: DebugConfiguration[] = workspaceConfiguration.configurations ?? [];
 
     let configurationIndex: number | undefined;
@@ -50,7 +50,7 @@ export default async function scaffoldConfiguration(name: string, contentFactory
         workspaceConfigurations.push(configuration);
     }
 
-    await workspaceConfiguration.update('configurations', workspaceConfigurations);
+    await workspaceConfiguration.update('configurations', workspaceConfigurations, vscode.ConfigurationTarget.WorkspaceFolder);
 
     return name;
 }

--- a/src/scaffolding/scaffolder.ts
+++ b/src/scaffolding/scaffolder.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as fse from 'fs-extra';
+import * as vscode from 'vscode';
 import scaffoldConfiguration, { ConfigurationContentFactory } from './configurationScaffolder';
 import scaffoldTask, { TaskContentFactory } from './taskScaffolder';
 import { ConflictHandler } from './conflicts';
@@ -9,14 +10,14 @@ import { ConflictHandler } from './conflicts';
 export type FileContentFactory = (path: string) => Promise<string>;
 
 export interface Scaffolder {
-    scaffoldConfiguration(name: string, contentFactory: ConfigurationContentFactory, onConflict: ConflictHandler): Promise<string | undefined>;
+    scaffoldConfiguration(name: string, folder: vscode.WorkspaceFolder, contentFactory: ConfigurationContentFactory, onConflict: ConflictHandler): Promise<string | undefined>;
     scaffoldFile(path: string, contentFactory: FileContentFactory, onConflict: ConflictHandler): Promise<string | undefined>;
-    scaffoldTask(label: string, contentFactory: TaskContentFactory, onConflict: ConflictHandler): Promise<string | undefined>;
+    scaffoldTask(label: string, folder: vscode.WorkspaceFolder, contentFactory: TaskContentFactory, onConflict: ConflictHandler): Promise<string | undefined>;
 }
 
 export default class LocalScaffolder implements Scaffolder {
-    scaffoldConfiguration(name: string, contentFactory: ConfigurationContentFactory, onConflict: ConflictHandler): Promise<string | undefined> {
-        return scaffoldConfiguration(name, contentFactory, onConflict);
+    scaffoldConfiguration(name: string, folder: vscode.WorkspaceFolder, contentFactory: ConfigurationContentFactory, onConflict: ConflictHandler): Promise<string | undefined> {
+        return scaffoldConfiguration(name, folder, contentFactory, onConflict);
     }
 
     async scaffoldFile(path: string, contentFactory: FileContentFactory, onConflict: ConflictHandler): Promise<string | undefined> {
@@ -39,7 +40,7 @@ export default class LocalScaffolder implements Scaffolder {
         return path;
     }
 
-    scaffoldTask(label: string, contentFactory: TaskContentFactory, onConflict: ConflictHandler): Promise<string | undefined> {
-        return scaffoldTask(label, contentFactory, onConflict);
+    scaffoldTask(label: string, folder: vscode.WorkspaceFolder, contentFactory: TaskContentFactory, onConflict: ConflictHandler): Promise<string | undefined> {
+        return scaffoldTask(label, folder, contentFactory, onConflict);
     }
 }

--- a/src/scaffolding/taskScaffolder.ts
+++ b/src/scaffolding/taskScaffolder.ts
@@ -7,14 +7,14 @@ import { ConflictHandler } from './conflicts';
 
 export type TaskContentFactory = (label: string) => TaskDefinition;
 
-export function getWorkspaceTasks(): TaskDefinition[] {
-    const workspaceConfigurations = vscode.workspace.getConfiguration('tasks');
+export function getWorkspaceTasks(folder: vscode.WorkspaceFolder): TaskDefinition[] {
+    const workspaceConfigurations = vscode.workspace.getConfiguration('tasks', folder.uri);
     
     return workspaceConfigurations.tasks ?? [];
 }
 
-export default async function scaffoldTask(label: string, contentFactory: TaskContentFactory, onConflict: ConflictHandler): Promise<string | undefined> {
-    const workspaceConfigurations = vscode.workspace.getConfiguration('tasks');
+export default async function scaffoldTask(label: string, folder: vscode.WorkspaceFolder, contentFactory: TaskContentFactory, onConflict: ConflictHandler): Promise<string | undefined> {
+    const workspaceConfigurations = vscode.workspace.getConfiguration('tasks', folder.uri);
     const workspaceTasks: TaskDefinition[] = workspaceConfigurations.tasks ?? [];
 
     let taskIndex: number | undefined;
@@ -46,7 +46,7 @@ export default async function scaffoldTask(label: string, contentFactory: TaskCo
         workspaceTasks.push(task);
     }
 
-    await workspaceConfigurations.update('tasks', workspaceTasks);
+    await workspaceConfigurations.update('tasks', workspaceTasks, vscode.ConfigurationTarget.WorkspaceFolder);
 
     return label;
 }


### PR DESCRIPTION
Like [`vscode-docker`](https://github.com/Microsoft/vscode-docker), to avoid VS Code's quirks with respect to tasks/configurations, we should only scaffold folder-scoped tasks/configurations even when a workspace is opened.

Resolves #88.