### PR TITLE
Switch default placement ports based on platform.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import createPlatformProcessProvider from './services/processProvider';
 import LocalDaprInstallationManager from './services/daprInstallationManager';
 import HandlebarsTemplateScaffolder from './scaffolding/templateScaffolder';
 import LocalScaffolder from './scaffolding/scaffolder';
+import NodeEnvironmentProvider from './services/environmentProvider';
 
 export function activate(context: vscode.ExtensionContext): Promise<void> {
 	function registerDisposable<T extends vscode.Disposable>(disposable: T): T {
@@ -69,7 +70,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			telemetryProvider.registerCommandWithTelemetry('vscode-dapr.tasks.scaffoldDaprTasks', createScaffoldDaprTasksCommand(scaffolder, templateScaffolder, ui));
 			
 			registerDisposable(vscode.tasks.registerTaskProvider('dapr', new DaprCommandTaskProvider(telemetryProvider)));
-			registerDisposable(vscode.tasks.registerTaskProvider('daprd', new DaprdCommandTaskProvider(telemetryProvider)));
+			registerDisposable(vscode.tasks.registerTaskProvider('daprd', new DaprdCommandTaskProvider(new NodeEnvironmentProvider(), telemetryProvider)));
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd-down', new DaprdDownTaskProvider(daprApplicationProvider, telemetryProvider)));
 			
 			registerDisposable(

--- a/src/services/environmentProvider.ts
+++ b/src/services/environmentProvider.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as os from 'os';
+
+export interface EnvironmentProvider {
+    readonly isWindows: boolean;
+}
+
+export default class NodeEnvironmentProvider implements EnvironmentProvider {
+    get isWindows(): boolean {
+        return os.platform() === 'win32';
+    }
+}

--- a/src/tasks/daprdCommandTaskProvider.ts
+++ b/src/tasks/daprdCommandTaskProvider.ts
@@ -5,6 +5,7 @@ import CommandLineBuilder from '../util/commandLineBuilder';
 import CommandTaskProvider from './commandTaskProvider';
 import { TaskDefinition } from './taskDefinition';
 import { TelemetryProvider } from '../services/telemetryProvider';
+import { EnvironmentProvider } from '../services/environmentProvider';
 
 type DaprdLogLevel = 'debug' | 'info' | 'warning' | 'error' | 'fatal' | 'panic';
 
@@ -41,7 +42,9 @@ export interface DaprdTaskDefinition extends TaskDefinition {
 }
 
 export default class DaprdCommandTaskProvider extends CommandTaskProvider {
-    constructor(telemetryProvider: TelemetryProvider) {
+    constructor(
+        environmentProvider: EnvironmentProvider,
+        telemetryProvider: TelemetryProvider) {
         super(
             (definition, callback) => {
                 return telemetryProvider.callWithTelemetry(
@@ -72,7 +75,7 @@ export default class DaprdCommandTaskProvider extends CommandTaskProvider {
                                 .withNamedArg('--max-concurrency', daprDefinition.maxConcurrency)
                                 .withNamedArg('--metrics-port', daprDefinition.metricsPort)
                                 .withNamedArg('--mode', daprDefinition.mode)
-                                .withNamedArg('--placement-address', daprDefinition.placementAddress ?? `${process.env.DAPR_PLACEMENT_HOST ?? 'localhost'}:50005` /* NOTE: The placement address is actually required for daprd. */)
+                                .withNamedArg('--placement-address', daprDefinition.placementAddress ?? `${process.env.DAPR_PLACEMENT_HOST ?? 'localhost'}:${environmentProvider.isWindows ? 6050 : 50005}` /* NOTE: The placement address is actually required for daprd. */)
                                 .withNamedArg('--profile-port', daprDefinition.profilePort)
                                 .withNamedArg('--protocol', daprDefinition.protocol)
                                 .withNamedArg('--sentry-address', daprDefinition.sentryAddress)


### PR DESCRIPTION
Updates the `daprd` task to default to the correct placement port when on Windows (versus the default used on other platforms).

Resolves #82.