### PR TITLE
Prefer DAPR_REDIS_HOST over default Redis host name.

### DIFF
--- a/src/scaffolding/daprComponentScaffolder.ts
+++ b/src/scaffolding/daprComponentScaffolder.ts
@@ -11,7 +11,7 @@ export async function scaffoldRedisComponent(scaffolder: Scaffolder, templateSca
     //       so use 'redis' rather than 'localhost'. 
     await scaffolder.scaffoldFile(
         path.join(folderPath, fileName),
-        () => templateScaffolder.scaffoldTemplate(name, { redisHost: redisHost ?? (process.env.DAPR_NETWORK ? 'redis' : 'localhost') }),
+        () => templateScaffolder.scaffoldTemplate(name, { redisHost: redisHost ?? process.env.DAPR_REDIS_HOST ?? (process.env.DAPR_NETWORK ? 'redis' : 'localhost') }),
         () => Promise.resolve({ 'type': 'skip' }));
 }
 


### PR DESCRIPTION
Updates the scaffolding to prefer the host specified by `DAPR_REDIS_HOST` before falling back to a default.

Resolves #84.