### PR TITLE
Add default for componentsPath property.

### DIFF
--- a/src/tasks/daprdCommandTaskProvider.ts
+++ b/src/tasks/daprdCommandTaskProvider.ts
@@ -59,7 +59,7 @@ export default class DaprdCommandTaskProvider extends CommandTaskProvider {
                                 .withNamedArg('--alsologtostderr', daprDefinition.alsoLogToStdErr, { assignValue: true })
                                 .withNamedArg('--app-id', daprDefinition.appId)
                                 .withNamedArg('--app-port', daprDefinition.appPort)
-                                .withNamedArg('--components-path', daprDefinition.componentsPath)
+                                .withNamedArg('--components-path', daprDefinition.componentsPath ?? './components')
                                 .withNamedArg('--config', daprDefinition.config)
                                 .withNamedArg('--control-plane-address', daprDefinition.controlPlaneAddress)
                                 .withNamedArg('--dapr-grpc-port', daprDefinition.grpcPort)


### PR DESCRIPTION
Adds `./components` as a default for the `componentsPath` property of the `daprd` task, as the `daprd` CLI no longer uses that as a default, if omitted.

Resolves #98.