### PR TITLE
Tweak detection of Dapr runtime state.

### DIFF
--- a/src/services/daprInstallationManager.ts
+++ b/src/services/daprInstallationManager.ts
@@ -56,15 +56,17 @@ export default class LocalDaprInstallationManager implements DaprInstallationMan
                 const psResult = await Process.exec(`docker ps --filter network=${network} --format "{{.ID}}"`);
 
                 if (psResult.code === 0) {
-                    const containerIds = psResult.stdout.split('\n').join(' ');
+                    const containerIds = psResult.stdout.split('\n').filter(id => id.length > 0);
 
-                    const inspectResult = await Process.exec(`docker inspect ${containerIds} --format "{{.Config.Image}}"`);
-
-                    if (inspectResult.code === 0) {
-                        const containerImages = inspectResult.stdout.split('\n');
-
-                        if (containerImages.find(image => image === 'daprio/dapr')) {
-                            return true;
+                    if (containerIds.length > 0) {
+                        const inspectResult = await Process.exec(`docker inspect ${containerIds.join(' ')} --format "{{.Config.Image}}"`);
+                        
+                        if (inspectResult.code === 0) {
+                            const containerImages = inspectResult.stdout.split('\n');
+                            
+                            if (containerImages.find(image => image === 'daprio/dapr')) {
+                                return true;
+                            }
                         }
                     }
                 }

--- a/src/services/daprInstallationManager.ts
+++ b/src/services/daprInstallationManager.ts
@@ -31,6 +31,9 @@ interface DockerProcessContainer {
     Image?: string;
 }
 
+const daprImageName = 'daprio/dapr';
+const daprTaggedImagePrefix = `${daprImageName}:`;
+
 export default class LocalDaprInstallationManager implements DaprInstallationManager {
     private readonly version: AsyncLazy<DaprVersion>;
     private readonly initialized: AsyncLazy<boolean>;
@@ -64,7 +67,7 @@ export default class LocalDaprInstallationManager implements DaprInstallationMan
                         if (inspectResult.code === 0) {
                             const containerImages = inspectResult.stdout.split('\n');
                             
-                            if (containerImages.find(image => image === 'daprio/dapr')) {
+                            if (containerImages.find(image => image === daprImageName || image.startsWith(daprTaggedImagePrefix))) {
                                 return true;
                             }
                         }

--- a/src/services/daprInstallationManager.ts
+++ b/src/services/daprInstallationManager.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as process from 'process';
 import { AsyncLazy } from '../util/lazy';
 import { Process } from '../util/process';
 
@@ -51,14 +52,15 @@ export default class LocalDaprInstallationManager implements DaprInstallationMan
 
         this.initialized = new AsyncLazy<boolean>(
             async () => {
-                const psResult = await Process.exec('docker ps --format "{{json .}}"');
+                const network = process.env.DAPR_NETWORK || 'bridge';
+                const psResult = await Process.exec(`docker ps --filter network=${network} --format "{{json .}}"`);
 
                 if (psResult.code === 0) {
                     const lines = psResult.stdout.split('\n');
                     const containers = lines.map(line => <DockerProcessContainer>JSON.parse(line));
                     const daprContainers = containers.filter(container => container.Image === 'daprio/dapr');
 
-                    if (daprContainers.length >= 0) {
+                    if (daprContainers.length >= 1) {
                         return true;
                     }
                 }

--- a/src/views/applications/noApplicationsRunningNode.ts
+++ b/src/views/applications/noApplicationsRunningNode.ts
@@ -11,17 +11,17 @@ export default class NoApplicationsRunningNode implements TreeNode {
     }
 
     async getTreeItem(): Promise<vscode.TreeItem> {
-        let label = localize('views.noApplicationsRunningNode.notInstalledLabel', 'The Dapr CLI and runtime do not appear to be installed.');
+        let label = localize('views.applications.noApplicationsRunningNode.notInstalledLabel', 'The Dapr CLI and runtime do not appear to be installed.');
 
         const version = await this.installationManager.getVersion();
         
         if (version && version.cli) {
-            label = localize('views.noApplicationsRunningNode.notInitializedLabel', 'The Dapr runtime does not appear to be initialized.');
+            label = localize('views.applications.noApplicationsRunningNode.notInitializedLabel', 'The Dapr runtime does not appear to be initialized.');
 
             const isInitialized = await this.installationManager.isInitialized();
 
             if (isInitialized) {
-                label = localize('views.noApplicationsRunningNode.label', 'No Dapr applications are running.')
+                label = localize('views.applications.noApplicationsRunningNode.notRunning', 'No Dapr applications are running.')
             }
         }
 


### PR DESCRIPTION
Updates the way we detect the current state of the Dapr runtime (i.e. not installed, not initialized, or no apps running), in particular, to better support when using the extension within a VS Code dev container.  Among the changes:

 - We only look for Dapr runtimes running on the current (either an explicit or default) Docker network.
 - We identify the Dapr runtime container using its inspected `Config.Image` property rather than `Image` property, as Docker sometimes reports the latter differently when running on different Docker networks (i.e. sometimes it's a SHA256 hash rather than the image name).

This should resolve #80.