### PR TITLE
Update per latest Dapr pub/sub spec.

### DIFF
--- a/src/services/daprClient.ts
+++ b/src/services/daprClient.ts
@@ -13,7 +13,7 @@ const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 export interface DaprClient {
     invokeGet(application: DaprApplication, method: string, token?: vscode.CancellationToken): Promise<unknown>;
     invokePost(application: DaprApplication, method: string, payload?: unknown, token?: vscode.CancellationToken): Promise<unknown>;
-    publishMessage(application: DaprApplication, topic: string, payload?: unknown, token?: vscode.CancellationToken): Promise<void>;
+    publishMessage(application: DaprApplication, pubSubName: string, topic: string, payload?: unknown, token?: vscode.CancellationToken): Promise<void>;
 }
 
 function manageResponse(response: HttpResponse): unknown {
@@ -55,8 +55,8 @@ export default class HttpDaprClient implements DaprClient {
         return manageResponse(response);
     }
 
-    async publishMessage(application: DaprApplication, topic: string, payload?: unknown, token?: vscode.CancellationToken): Promise<void> {
-        const url = `http://localhost:${application.httpPort}/v1.0/publish/${topic}`;
+    async publishMessage(application: DaprApplication, pubSubName: string, topic: string, payload?: unknown, token?: vscode.CancellationToken): Promise<void> {
+        const url = `http://localhost:${application.httpPort}/v1.0/publish/${pubSubName}/${topic}`;
 
         await this.httpClient.post(url, payload, { json: true }, token);
     }


### PR DESCRIPTION
At some point, the Dapr publish/subscribe spec changed to require specifying the "pubsubname" (i.e. the component used to perform the publish/subscribe), both when subscribing from the application code as well as when building the URL to publish a message.

This change updates the publish message command to prompt the user for the "pubsubname" and uses that in the URL used to publish the message.

Resolves #117.