### PR TITLE
Better handle empty POST and publish payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Change Log
 
-## v0.3.0 - 02 September 2020
+## v0.3.0 - 03 September 2020
 
 A collection of accumulated fixes and minor enhancements.
 
 ### Fixed
 
+* Pop up an error when invoking (POST) application method with an empty payload [#121](https://github.com/microsoft/vscode-dapr/issues/121)
 * Pop up an error "Request failed with status code 404" when publishing message [#117](https://github.com/microsoft/vscode-dapr/issues/117)
 * The default value of the port is "app" when invoking "Dapr: Scaffold Dapr Tasks" command [#109](https://github.com/microsoft/vscode-dapr/issues/109)
 * It shows "Failed to load message bundle..." after expanding "APPLICATIONS" [#104](https://github.com/microsoft/vscode-dapr/issues/104)

--- a/src/commands/applications/invokeCommon.ts
+++ b/src/commands/applications/invokeCommon.ts
@@ -76,7 +76,7 @@ export async function getPayload(context: ITelemetryContext, ui: UserInput, work
             value: previousPayloadString
         });
 
-    const payload = (payloadString && <unknown>JSON.parse(payloadString)) || undefined;
+    const payload = payloadString ? <unknown>JSON.parse(payloadString) : undefined;
 
     await workspaceState.update(payLoadStateKey, payloadString);
 

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -58,14 +58,16 @@ export default class AxiosHttpClient implements HttpClient {
 
         const config = createConfig(options?.allowRedirects, cancelTokenSource.token);
 
-        config.headers = {
-            'content-type': options?.json ? 'application/json' : undefined
-        };
+        if (data !== undefined) {
+            config.headers = {
+                'content-type': options?.json ? 'application/json' : undefined
+            };
+        }
 
         try {
             const response = await axios.post<unknown>(
                 url,
-                options?.json ? JSON.stringify(data) : data,
+                (data !== undefined && options?.json) ? JSON.stringify(data) : data,
                 config);
 
             return { data: response.data, headers: <{[key: string]: string}>response.headers, status: response.status };


### PR DESCRIPTION
Tweaks the way payloads are handled for POST and publish commands, so we don't attempt to write add an undefined (i.e. empty) payload.

Resolves #121.