### PR TITLE
Add settings for explicit Dapr binary paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "vscode-dapr",
-	"version": "0.3.1-alpha",
+	"version": "0.4.1-alpha",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@azure/abort-controller": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.2.tgz",
-			"integrity": "sha512-XUyTo+bcyxHEf+jlN2MXA7YU9nxVehaubngHV1MIZZaqYmZqykkoeAz/JMMEeR7t3TcyDwbFa3Zw8BZywmIx4g==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.4.tgz",
+			"integrity": "sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==",
 			"requires": {
 				"tslib": "^2.0.0"
 			},
@@ -30,9 +30,9 @@
 			}
 		},
 		"@azure/arm-storage": {
-			"version": "15.2.0",
-			"resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-15.2.0.tgz",
-			"integrity": "sha512-Q6DO2V5CxtjxGOZpsDJ2skXfIBhxGELqBpfFedcAjarcmS7hIiDlEPCDkaezfcSMjutwq/phBpgisQu7mV1HDQ==",
+			"version": "15.3.0",
+			"resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-15.3.0.tgz",
+			"integrity": "sha512-djN2tmEzvC4lNEYrk3PAXkf5ZcebGDqPZSh/cYKOleumD4eop5EpMX8d5LcSO/9EcSfPpCzutRg0AleMaPQ9Mg==",
 			"requires": {
 				"@azure/ms-rest-azure-js": "^2.0.1",
 				"@azure/ms-rest-js": "^2.0.4",
@@ -125,9 +125,9 @@
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-			"integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+			"integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
@@ -137,7 +137,6 @@
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
-				"lodash": "^4.17.20",
 				"minimatch": "^3.0.4",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -158,12 +157,6 @@
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-					"dev": true
-				},
-				"lodash": {
-					"version": "4.17.20",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 					"dev": true
 				}
 			}
@@ -260,9 +253,9 @@
 			"dev": true
 		},
 		"@types/eslint": {
-			"version": "7.2.6",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
-			"integrity": "sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==",
+			"version": "7.2.7",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.7.tgz",
+			"integrity": "sha512-EHXbc1z2GoQRqHaAT7+grxlTJ3WE2YNeD6jlpPoRc83cCoThRY+NUWjCUZaYmk51OICkPXn2hhphcWcWXgNW0Q==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "*",
@@ -292,9 +285,9 @@
 			"dev": true
 		},
 		"@types/fs-extra": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.7.tgz",
-			"integrity": "sha512-YGq2A6Yc3bldrLUlm17VNWOnUbnEzJ9CMgOeLFtQF3HOCN5lQBO8VyjG00a5acA5NNSM30kHVGp1trZgnVgi1Q==",
+			"version": "9.0.8",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.8.tgz",
+			"integrity": "sha512-bnlTVTwq03Na7DpWxFJ1dvnORob+Otb8xHyUqUWhqvz/Ksg8+JXPlR52oeMSZ37YEOa5PyccbgUNutiQdi13TA==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -461,9 +454,9 @@
 			"dev": true
 		},
 		"@types/mocha": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.0.tgz",
-			"integrity": "sha512-/Sge3BymXo4lKc31C8OINJgXLaw+7vL1/L1pGiBNpGrBiT8FQiaFpSYV0uhTaG4y78vcMBTMFsWaHDvuD+xGzQ==",
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
+			"integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
 			"dev": true
 		},
 		"@types/node": {
@@ -579,9 +572,9 @@
 			}
 		},
 		"@types/vscode": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz",
-			"integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.54.0.tgz",
+			"integrity": "sha512-sHHw9HG4bTrnKhLGgmEiOS88OLO/2RQytUN4COX9Djv81zc0FSZsSiYaVyjNidDzUSpXsySKBkZ31lk2/FbdCg==",
 			"dev": true
 		},
 		"@types/webpack": {
@@ -618,13 +611,13 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.1.tgz",
-			"integrity": "sha512-yW2epMYZSpNJXZy22Biu+fLdTG8Mn6b22kR3TqblVk50HGNV8Zya15WAXuQCr8tKw4Qf1BL4QtI6kv6PCkLoJw==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.19.0.tgz",
+			"integrity": "sha512-CRQNQ0mC2Pa7VLwKFbrGVTArfdVDdefS+gTw0oC98vSI98IX5A8EVH4BzJ2FOB0YlCmm8Im36Elad/Jgtvveaw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "4.15.1",
-				"@typescript-eslint/scope-manager": "4.15.1",
+				"@typescript-eslint/experimental-utils": "4.19.0",
+				"@typescript-eslint/scope-manager": "4.19.0",
 				"debug": "^4.1.1",
 				"functional-red-black-tree": "^1.0.1",
 				"lodash": "^4.17.15",
@@ -634,9 +627,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -645,55 +638,55 @@
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.1.tgz",
-			"integrity": "sha512-9LQRmOzBRI1iOdJorr4jEnQhadxK4c9R2aEAsm7WE/7dq8wkKD1suaV0S/JucTL8QlYUPU1y2yjqg+aGC0IQBQ==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.19.0.tgz",
+			"integrity": "sha512-9/23F1nnyzbHKuoTqFN1iXwN3bvOm/PRIXSBR3qFAYotK/0LveEOHr5JT1WZSzcD6BESl8kPOG3OoDRKO84bHA==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/scope-manager": "4.15.1",
-				"@typescript-eslint/types": "4.15.1",
-				"@typescript-eslint/typescript-estree": "4.15.1",
+				"@typescript-eslint/scope-manager": "4.19.0",
+				"@typescript-eslint/types": "4.19.0",
+				"@typescript-eslint/typescript-estree": "4.19.0",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.15.1.tgz",
-			"integrity": "sha512-V8eXYxNJ9QmXi5ETDguB7O9diAXlIyS+e3xzLoP/oVE4WCAjssxLIa0mqCLsCGXulYJUfT+GV70Jv1vHsdKwtA==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.19.0.tgz",
+			"integrity": "sha512-/uabZjo2ZZhm66rdAu21HA8nQebl3lAIDcybUoOxoI7VbZBYavLIwtOOmykKCJy+Xq6Vw6ugkiwn8Js7D6wieA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "4.15.1",
-				"@typescript-eslint/types": "4.15.1",
-				"@typescript-eslint/typescript-estree": "4.15.1",
+				"@typescript-eslint/scope-manager": "4.19.0",
+				"@typescript-eslint/types": "4.19.0",
+				"@typescript-eslint/typescript-estree": "4.19.0",
 				"debug": "^4.1.1"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.1.tgz",
-			"integrity": "sha512-ibQrTFcAm7yG4C1iwpIYK7vDnFg+fKaZVfvyOm3sNsGAerKfwPVFtYft5EbjzByDJ4dj1WD8/34REJfw/9wdVA==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.19.0.tgz",
+			"integrity": "sha512-GGy4Ba/hLXwJXygkXqMzduqOMc+Na6LrJTZXJWVhRrSuZeXmu8TAnniQVKgj8uTRKe4igO2ysYzH+Np879G75g==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.15.1",
-				"@typescript-eslint/visitor-keys": "4.15.1"
+				"@typescript-eslint/types": "4.19.0",
+				"@typescript-eslint/visitor-keys": "4.19.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.1.tgz",
-			"integrity": "sha512-iGsaUyWFyLz0mHfXhX4zO6P7O3sExQpBJ2dgXB0G5g/8PRVfBBsmQIc3r83ranEQTALLR3Vko/fnCIVqmH+mPw==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.19.0.tgz",
+			"integrity": "sha512-A4iAlexVvd4IBsSTNxdvdepW0D4uR/fwxDrKUa+iEY9UWvGREu2ZyB8ylTENM1SH8F7bVC9ac9+si3LWNxcBuA==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.1.tgz",
-			"integrity": "sha512-z8MN3CicTEumrWAEB2e2CcoZa3KP9+SMYLIA2aM49XW3cWIaiVSOAGq30ffR5XHxRirqE90fgLw3e6WmNx5uNw==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.19.0.tgz",
+			"integrity": "sha512-3xqArJ/A62smaQYRv2ZFyTA+XxGGWmlDYrsfZG68zJeNbeqRScnhf81rUVa6QG4UgzHnXw5VnMT5cg75dQGDkA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.15.1",
-				"@typescript-eslint/visitor-keys": "4.15.1",
+				"@typescript-eslint/types": "4.19.0",
+				"@typescript-eslint/visitor-keys": "4.19.0",
 				"debug": "^4.1.1",
 				"globby": "^11.0.1",
 				"is-glob": "^4.0.1",
@@ -702,9 +695,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -713,12 +706,12 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.1.tgz",
-			"integrity": "sha512-tYzaTP9plooRJY8eNlpAewTOqtWW/4ff/5wBjNVaJ0S0wC4Gpq/zDVRTJa5bq2v1pCNQ08xxMCndcvR+h7lMww==",
+			"version": "4.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.19.0.tgz",
+			"integrity": "sha512-aGPS6kz//j7XLSlgpzU2SeTqHPsmRYxFztj2vPuMMFJXZudpRSehE3WCV+BaxwZFvfAqMoSd86TEuM0PQ59E/A==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.15.1",
+				"@typescript-eslint/types": "4.19.0",
 				"eslint-visitor-keys": "^2.0.0"
 			},
 			"dependencies": {
@@ -1521,9 +1514,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001187",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001187.tgz",
-			"integrity": "sha512-w7/EP1JRZ9552CyrThUnay2RkZ1DXxKe/Q2swTC4+LElLh9RRYrL1Z+27LlakB8kzY0fSmHw9mc7XYDUKAKWMA==",
+			"version": "1.0.30001204",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
+			"integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==",
 			"dev": true
 		},
 		"chainsaw": {
@@ -1605,9 +1598,9 @@
 					}
 				},
 				"domutils": {
-					"version": "2.4.4",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-					"integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.0.tgz",
+					"integrity": "sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==",
 					"dev": true,
 					"requires": {
 						"dom-serializer": "^1.0.1",
@@ -1622,9 +1615,9 @@
 					"dev": true
 				},
 				"htmlparser2": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.0.tgz",
-					"integrity": "sha512-numTQtDZMoh78zJpaNdJ9MXb2cv5G3jwUoe3dMQODubZvLoGvTE/Ofp6sHvH8OGKcN/8A47pGLi/k58xHP/Tfw==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.1.tgz",
+					"integrity": "sha512-GDKPd+vk4jvSuvCbyuzx/unmXkk090Azec7LovXP8as1Hn8q9p3hbjmDGbUqqhknw0ajwit6LiiWqfiTUPMK7w==",
 					"dev": true,
 					"requires": {
 						"domelementtype": "^2.0.1",
@@ -1675,9 +1668,9 @@
 					}
 				},
 				"domutils": {
-					"version": "2.4.4",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-					"integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.0.tgz",
+					"integrity": "sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==",
 					"dev": true,
 					"requires": {
 						"dom-serializer": "^1.0.1",
@@ -1943,9 +1936,9 @@
 			"dev": true
 		},
 		"colorette": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-			"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
 			"dev": true
 		},
 		"combined-stream": {
@@ -2157,9 +2150,9 @@
 					}
 				},
 				"domutils": {
-					"version": "2.4.4",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-					"integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.0.tgz",
+					"integrity": "sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==",
 					"dev": true,
 					"requires": {
 						"dom-serializer": "^1.0.1",
@@ -2572,9 +2565,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.665",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.665.tgz",
-			"integrity": "sha512-LIjx1JheOz7LM8DMEQ2tPnbBzJ4nVG1MKutsbEMLnJfwfVdPIsyagqfLp56bOWhdBrYGXWHaTayYkllIU2TauA==",
+			"version": "1.3.699",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.699.tgz",
+			"integrity": "sha512-fjt43CPXdPYwD9ybmKbNeLwZBmCVdLY2J5fGZub7/eMPuiqQznOGNXv/wurnpXIlE7ScHnvG9Zi+H4/i6uMKmw==",
 			"dev": true
 		},
 		"emitter-listener": {
@@ -2657,9 +2650,9 @@
 			}
 		},
 		"es-module-lexer": {
-			"version": "0.3.26",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.26.tgz",
-			"integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
+			"integrity": "sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==",
 			"dev": true
 		},
 		"es5-ext": {
@@ -2719,13 +2712,13 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.20.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
-			"integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
+			"version": "7.22.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.22.0.tgz",
+			"integrity": "sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.3.0",
+				"@eslint/eslintrc": "^0.4.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -2738,10 +2731,10 @@
 				"espree": "^7.3.1",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
-				"file-entry-cache": "^6.0.0",
+				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^5.0.0",
-				"globals": "^12.1.0",
+				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
@@ -2749,7 +2742,7 @@
 				"js-yaml": "^3.13.1",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
-				"lodash": "^4.17.20",
+				"lodash": "^4.17.21",
 				"minimatch": "^3.0.4",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.1",
@@ -2773,9 +2766,9 @@
 					}
 				},
 				"@babel/highlight": {
-					"version": "7.12.13",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-					"integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.12.11",
@@ -2916,9 +2909,9 @@
 					"dev": true
 				},
 				"file-entry-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
-					"integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+					"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 					"dev": true,
 					"requires": {
 						"flat-cache": "^3.0.4"
@@ -2940,6 +2933,15 @@
 					"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
 					"dev": true
 				},
+				"globals": {
+					"version": "13.7.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.7.0.tgz",
+					"integrity": "sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.20.2"
+					}
+				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2953,15 +2955,15 @@
 					"dev": true
 				},
 				"lodash": {
-					"version": "4.17.20",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 					"dev": true
 				},
 				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -2990,9 +2992,9 @@
 					}
 				},
 				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
@@ -3022,9 +3024,9 @@
 					},
 					"dependencies": {
 						"ajv": {
-							"version": "7.1.0",
-							"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.0.tgz",
-							"integrity": "sha512-svS9uILze/cXbH0z2myCK2Brqprx/+JJYK5pHicT/GQiBfzzhUVAIT6MwqJg8y4xV/zoGsUeuPuwtoiKSGE15g==",
+							"version": "7.2.3",
+							"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.3.tgz",
+							"integrity": "sha512-idv5WZvKVXDqKralOImQgPM9v6WOdLNa0IY3B3doOjw/YxRGT8I+allIJ6kd7Uaj+SF1xZUSU+nPM5aDNBVtnw==",
 							"dev": true,
 							"requires": {
 								"fast-deep-equal": "^3.1.1",
@@ -3034,6 +3036,12 @@
 							}
 						}
 					}
+				},
+				"type-fest": {
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+					"dev": true
 				}
 			}
 		},
@@ -3168,9 +3176,9 @@
 			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
 		},
 		"events": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-			"integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"dev": true
 		},
 		"expand-brackets": {
@@ -6032,9 +6040,9 @@
 			}
 		},
 		"mocha": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
-			"integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.2.tgz",
+			"integrity": "sha512-UdmISwr/5w+uXLPKspgoV7/RXZwKRTiTjJ2/AC5ZiEztIoOYdfKb19+9jNmEInzx5pBsCyJQzarAxqIGBNYJhg==",
 			"dev": true,
 			"requires": {
 				"@ungap/promise-all-settled": "1.1.2",
@@ -6238,9 +6246,9 @@
 					}
 				},
 				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
@@ -6394,9 +6402,9 @@
 			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
 		"node-releases": {
-			"version": "1.1.70",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.70.tgz",
-			"integrity": "sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==",
+			"version": "1.1.71",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
 			"dev": true
 		},
 		"normalize-package-data": {
@@ -7874,9 +7882,9 @@
 			"dev": true
 		},
 		"tas-client": {
-			"version": "0.1.16",
-			"resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.16.tgz",
-			"integrity": "sha512-ZMGg7dGXiYVJHYusDpUb/Ilg+iPNYZdKJSIA2ADn0f2RovHWM0TpNVe2YHPEc0hdFMsUwWKS5pCRzLnlUqcqGg==",
+			"version": "0.1.21",
+			"resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.21.tgz",
+			"integrity": "sha512-7UuIwOXarCYoCTrQHY5n7M+63XuwMC0sVUdbPQzxqDB9wMjIW0JF39dnp3yoJnxr4jJUVhPtvkkXZbAD0BxCcA==",
 			"requires": {
 				"axios": "^0.21.1"
 			}
@@ -8117,9 +8125,9 @@
 			"dev": true
 		},
 		"ts-loader": {
-			"version": "8.0.17",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.17.tgz",
-			"integrity": "sha512-OeVfSshx6ot/TCxRwpBHQ/4lRzfgyTkvi7ghDVrLXOHzTbSK413ROgu/xNqM72i3AFeAIJgQy78FwSMKmOW68w==",
+			"version": "8.0.18",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.18.tgz",
+			"integrity": "sha512-hRZzkydPX30XkLaQwJTDcWDoxZHK6IrEMDQpNd7tgcakFruFkeUp/aY+9hBb7BUGb+ZWKI0jiOGMo0MckwzdDQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0",
@@ -8209,9 +8217,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -8292,9 +8300,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "3.20.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.20.0.tgz",
-			"integrity": "sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
@@ -8351,9 +8359,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+			"integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
 			"dev": true
 		},
 		"uc.micro": {
@@ -8681,9 +8689,9 @@
 			}
 		},
 		"vsce": {
-			"version": "1.85.0",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.85.0.tgz",
-			"integrity": "sha512-YVFwjXWvHRwk75mm3iL4Wr3auCdbBPTv2amtLf97ccqH0hkt0ZVBddu7iOs4HSEbSr9xiiaZwQHUsqMm6Ks0ag==",
+			"version": "1.87.0",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.87.0.tgz",
+			"integrity": "sha512-7Ow05XxIM4gHBq/Ho3hefdmiZG0fddHtu0M0XJ1sojyZBvxPxTHaMuBsRnfnMzgCqxDTFI5iLr94AgiwQnhOMQ==",
 			"dev": true,
 			"requires": {
 				"azure-devops-node-api": "^7.2.0",
@@ -8717,9 +8725,9 @@
 			}
 		},
 		"vscode-azureextensionui": {
-			"version": "0.39.2",
-			"resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.39.2.tgz",
-			"integrity": "sha512-ekDnGW4K60tracj4hjWrcvsduOfIeEI+i0soqSim67JeGmpji/zIBx82bPl5n9w6PnEOG8+UiKglOxK8//Z/YA==",
+			"version": "0.40.0",
+			"resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.40.0.tgz",
+			"integrity": "sha512-fKvVon7YgrtVVsTNtXT7XjNZKrKtYtdwQekWtAcqHLf3wpsfvBHjwZ85p+dfiAeDsd4EFqbheF+raqjBaDFxLg==",
 			"requires": {
 				"@azure/arm-resources": "^3.0.0",
 				"@azure/arm-storage": "^15.0.0",
@@ -8734,7 +8742,7 @@
 				"semver": "^5.7.1",
 				"vscode-extension-telemetry": "^0.1.5",
 				"vscode-nls": "^4.1.1",
-				"vscode-tas-client": "^0.1.17"
+				"vscode-tas-client": "^0.1.22"
 			},
 			"dependencies": {
 				"escape-string-regexp": {
@@ -8773,9 +8781,9 @@
 			}
 		},
 		"vscode-extension-telemetry": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.6.tgz",
-			"integrity": "sha512-rbzSg7k4NnsCdF4Lz0gI4jl3JLXR0hnlmfFgsY8CSDYhXgdoIxcre8jw5rjkobY0xhSDhbG7xCjP8zxskySJ/g==",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.7.tgz",
+			"integrity": "sha512-pZuZTHO9OpsrwlerOKotWBRLRYJ53DobYb7aWiRAXjlqkuqE+YJJaP+2WEy8GrLIF1EnitXTDMaTAKsmLQ5ORQ==",
 			"requires": {
 				"applicationinsights": "1.7.4"
 			}
@@ -8820,11 +8828,11 @@
 			}
 		},
 		"vscode-tas-client": {
-			"version": "0.1.17",
-			"resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.17.tgz",
-			"integrity": "sha512-5uqMeg7sjsu1/QkmuRtBOXtZnnrCXAMEihbOSxan3bk2NdA/nZvhfhfLh8gd9FlBBL56QH69I8Zn25B2yGPRng==",
+			"version": "0.1.22",
+			"resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.22.tgz",
+			"integrity": "sha512-1sYH73nhiSRVQgfZkLQNJW7VzhKM9qNbCe8QyXgiKkLhH4GflDXRPAK4yy4P41jUgula+Fc9G7i5imj1dlKfaw==",
 			"requires": {
-				"tas-client": "0.1.16"
+				"tas-client": "0.1.21"
 			}
 		},
 		"vscode-test": {
@@ -8850,9 +8858,9 @@
 			}
 		},
 		"webpack": {
-			"version": "5.22.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.22.0.tgz",
-			"integrity": "sha512-xqlb6r9RUXda/d9iA6P7YRTP1ChWeP50TEESKMMNIg0u8/Rb66zN9YJJO7oYgJTRyFyYi43NVC5feG45FSO1vQ==",
+			"version": "5.28.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.28.0.tgz",
+			"integrity": "sha512-1xllYVmA4dIvRjHzwELgW4KjIU1fW4PEuEnjsylz7k7H5HgPOctIq7W1jrt3sKH9yG5d72//XWzsHhfoWvsQVg==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.0",
@@ -8864,7 +8872,7 @@
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
 				"enhanced-resolve": "^5.7.0",
-				"es-module-lexer": "^0.3.26",
+				"es-module-lexer": "^0.4.0",
 				"eslint-scope": "^5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
@@ -8881,9 +8889,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "8.0.5",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
-					"integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
+					"integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
 					"dev": true
 				},
 				"eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,10 @@
 		"configuration": {
 			"title": "Dapr",
 			"properties": {
+				"vscode-dapr.configuration.daprPath": {
+					"type": "string",
+					"description": "%vscode-dapr.configuration.daprPath.description%"
+				},
 				"vscode-dapr.configuration.daprdPath": {
 					"type": "string",
 					"description": "%vscode-dapr.configuration.daprdPath.description%"

--- a/package.json
+++ b/package.json
@@ -100,6 +100,15 @@
 				"category": "Dapr"
 			}
 		],
+		"configuration": {
+			"title": "Dapr",
+			"properties": {
+				"vscode-dapr.configuration.daprdPath": {
+					"type": "string",
+					"description": "%vscode-dapr.configuration.daprdPath.description%"
+				}
+			}
+		},
 		"menus": {
 			"view/item/context": [
 				{
@@ -404,7 +413,7 @@
 			"activitybar": [
 				{
 					"id": "dapr-explorer",
-					"title": "Dapr",
+					"title": "%vscode-dapr.view-containers.dapr-explorer.title%",
 					"icon": "assets/images/dapr.svg"
 				}
 			]

--- a/package.json
+++ b/package.json
@@ -103,13 +103,13 @@
 		"configuration": {
 			"title": "Dapr",
 			"properties": {
-				"vscode-dapr.configuration.daprPath": {
+				"dapr.paths.daprPath": {
 					"type": "string",
-					"description": "%vscode-dapr.configuration.daprPath.description%"
+					"description": "%vscode-dapr.configuration.paths.daprPath.description%"
 				},
-				"vscode-dapr.configuration.daprdPath": {
+				"dapr.paths.daprdPath": {
 					"type": "string",
-					"description": "%vscode-dapr.configuration.daprdPath.description%"
+					"description": "%vscode-dapr.configuration.paths.daprdPath.description%"
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Dapr",
 	"description": "Makes it easy to run, debug, and interact with Dapr-enabled applications.",
 	"icon": "assets/images/extensionIcon.png",
-	"version": "0.4.0",
+	"version": "0.4.1-alpha",
 	"preview": true,
 	"publisher": "ms-azuretools",
 	"license": "SEE LICENSE IN LICENSE.txt",
@@ -13,7 +13,7 @@
 		"ui"
 	],
 	"engines": {
-		"vscode": "^1.53.0"
+		"vscode": "^1.54.0"
 	},
 	"categories": [
 		"Debuggers",
@@ -422,43 +422,43 @@
 		"test": "gulp test"
 	},
 	"devDependencies": {
-		"@types/fs-extra": "^9.0.7",
+		"@types/fs-extra": "^9.0.8",
 		"@types/glob": "^7.1.3",
 		"@types/gulp": "^4.0.8",
 		"@types/gulp-sourcemaps": "0.0.34",
 		"@types/handlebars": "^4.1.0",
-		"@types/mocha": "^8.2.0",
+		"@types/mocha": "^8.2.2",
 		"@types/node": "^12.20.1",
 		"@types/ps-list": "^6.2.1",
 		"@types/terser-webpack-plugin": "^5.0.2",
-		"@types/vscode": "^1.53.0",
+		"@types/vscode": "^1.54.0",
 		"@types/webpack": "^4.41.26",
-		"@typescript-eslint/eslint-plugin": "^4.15.1",
-		"@typescript-eslint/parser": "^4.15.1",
+		"@typescript-eslint/eslint-plugin": "^4.19.0",
+		"@typescript-eslint/parser": "^4.19.0",
 		"del": "^6.0.0",
-		"eslint": "^7.20.0",
+		"eslint": "^7.22.0",
 		"glob": "^7.1.5",
 		"gulp": "^4.0.2",
 		"gulp-eslint": "^6.0.0",
 		"gulp-sourcemaps": "^3.0.0",
 		"gulp-typescript": "^6.0.0-alpha.1",
-		"mocha": "^8.3.0",
+		"mocha": "^8.3.2",
 		"terser-webpack-plugin": "^5.1.1",
-		"ts-loader": "^8.0.17",
+		"ts-loader": "^8.0.18",
 		"ts-node": "^9.1.1",
 		"tslint": "^6.1.3",
-		"typescript": "^4.1.5",
-		"vsce": "^1.85.0",
+		"typescript": "^4.2.3",
+		"vsce": "^1.87.0",
 		"vscode-nls-dev": "^3.3.2",
 		"vscode-test": "^1.5.1",
-		"webpack": "^5.22.0"
+		"webpack": "^5.28.0"
 	},
 	"dependencies": {
 		"axios": "^0.21.1",
 		"fs-extra": "^9.1.0",
 		"handlebars": "^4.7.7",
 		"ps-list": "^7.2.0",
-		"vscode-azureextensionui": "^0.39.2",
+		"vscode-azureextensionui": "^0.40.0",
 		"vscode-nls": "^5.0.0"
 	}
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,8 +4,8 @@
     "vscode-dapr.applications.publish-message.title": "Publish Message to Application",
     "vscode-dapr.applications.publish-all-message.title": "Publish Message to All Applications",
 
-    "vscode-dapr.configuration.daprPath.description": "The full path to the dapr binary.",
-    "vscode-dapr.configuration.daprdPath.description": "The full path to the daprd binary.",
+    "vscode-dapr.configuration.paths.daprPath.description": "The full path to the dapr binary.",
+    "vscode-dapr.configuration.paths.daprdPath.description": "The full path to the daprd binary.",
 
     "vscode-dapr.help.readDocumentation.title": "Read Documentation",
     "vscode-dapr.help.getStarted.title": "Get Started",

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,6 +3,9 @@
     "vscode-dapr.applications.invoke-post.title": "Invoke (POST) Application Method",
     "vscode-dapr.applications.publish-message.title": "Publish Message to Application",
     "vscode-dapr.applications.publish-all-message.title": "Publish Message to All Applications",
+
+    "vscode-dapr.configuration.daprdPath.description": "The full path to the daprd binary.",
+
     "vscode-dapr.help.readDocumentation.title": "Read Documentation",
     "vscode-dapr.help.getStarted.title": "Get Started",
     "vscode-dapr.help.reportIssue.title": "Report Issue",
@@ -12,6 +15,8 @@
     "vscode-dapr.views.applications.name": "Applications",
     "vscode-dapr.views.help.name": "Help and Feedback",
 
+    "vscode-dapr.view-containers.dapr-explorer.title": "Dapr",
+    
     "vscode-dapr.tasks.dapr.properties.appId.description": "An ID for your application, used for service discovery.",
     "vscode-dapr.tasks.dapr.properties.appMaxConcurrency.description": "Controls the concurrency level of the application.",
     "vscode-dapr.tasks.dapr.properties.appPort.description": "The port your application is listening on.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,6 +4,7 @@
     "vscode-dapr.applications.publish-message.title": "Publish Message to Application",
     "vscode-dapr.applications.publish-all-message.title": "Publish Message to All Applications",
 
+    "vscode-dapr.configuration.daprPath.description": "The full path to the dapr binary.",
     "vscode-dapr.configuration.daprdPath.description": "The full path to the daprd binary.",
 
     "vscode-dapr.help.readDocumentation.title": "Read Documentation",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import HandlebarsTemplateScaffolder from './scaffolding/templateScaffolder';
 import LocalScaffolder from './scaffolding/scaffolder';
 import NodeEnvironmentProvider from './services/environmentProvider';
 import createScaffoldDaprComponentsCommand from './commands/scaffoldDaprComponents';
+import VsCodeSettingsProvider from './services/settingsProvider';
 
 export function activate(context: vscode.ExtensionContext): Promise<void> {
 	function registerDisposable<T extends vscode.Disposable>(disposable: T): T {
@@ -70,8 +71,10 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			telemetryProvider.registerCommandWithTelemetry('vscode-dapr.tasks.scaffoldDaprComponents', createScaffoldDaprComponentsCommand(scaffolder, templateScaffolder));
 			telemetryProvider.registerCommandWithTelemetry('vscode-dapr.tasks.scaffoldDaprTasks', createScaffoldDaprTasksCommand(scaffolder, templateScaffolder, ui));
 			
+			const settingsProvider = new VsCodeSettingsProvider();
+
 			registerDisposable(vscode.tasks.registerTaskProvider('dapr', new DaprCommandTaskProvider(telemetryProvider)));
-			registerDisposable(vscode.tasks.registerTaskProvider('daprd', new DaprdCommandTaskProvider(new NodeEnvironmentProvider(), telemetryProvider)));
+			registerDisposable(vscode.tasks.registerTaskProvider('daprd', new DaprdCommandTaskProvider(() => settingsProvider.daprdPath, new NodeEnvironmentProvider(), telemetryProvider)));
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd-down', new DaprdDownTaskProvider(daprApplicationProvider, telemetryProvider)));
 			
 			registerDisposable(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,7 +73,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			
 			const settingsProvider = new VsCodeSettingsProvider();
 
-			registerDisposable(vscode.tasks.registerTaskProvider('dapr', new DaprCommandTaskProvider(telemetryProvider)));
+			registerDisposable(vscode.tasks.registerTaskProvider('dapr', new DaprCommandTaskProvider(() => settingsProvider.daprdPath, telemetryProvider)));
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd', new DaprdCommandTaskProvider(() => settingsProvider.daprdPath, new NodeEnvironmentProvider(), telemetryProvider)));
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd-down', new DaprdDownTaskProvider(daprApplicationProvider, telemetryProvider)));
 			

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,7 +73,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			
 			const settingsProvider = new VsCodeSettingsProvider();
 
-			registerDisposable(vscode.tasks.registerTaskProvider('dapr', new DaprCommandTaskProvider(() => settingsProvider.daprdPath, telemetryProvider)));
+			registerDisposable(vscode.tasks.registerTaskProvider('dapr', new DaprCommandTaskProvider(() => settingsProvider.daprPath, telemetryProvider)));
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd', new DaprdCommandTaskProvider(() => settingsProvider.daprdPath, new NodeEnvironmentProvider(), telemetryProvider)));
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd-down', new DaprdDownTaskProvider(daprApplicationProvider, telemetryProvider)));
 			

--- a/src/services/settingsProvider.ts
+++ b/src/services/settingsProvider.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode';
+
+export interface SettingsProvider {
+    readonly daprdPath: string;
+}
+
+export default class VsCodeSettingsProvider implements SettingsProvider {
+    get daprdPath(): string {
+        const configuration = vscode.workspace.getConfiguration('vscode-dapr.configuration');
+
+        return configuration.get('daprdPath') || 'daprd';
+    }
+}

--- a/src/services/settingsProvider.ts
+++ b/src/services/settingsProvider.ts
@@ -15,7 +15,7 @@ export default class VsCodeSettingsProvider implements SettingsProvider {
     }
 
     private getConfigurationValue(name: string): string | undefined {
-        const configuration = vscode.workspace.getConfiguration('vscode-dapr.configuration');
+        const configuration = vscode.workspace.getConfiguration('dapr.paths');
 
         return configuration.get(name);
     }

--- a/src/services/settingsProvider.ts
+++ b/src/services/settingsProvider.ts
@@ -1,13 +1,22 @@
 import * as vscode from 'vscode';
 
 export interface SettingsProvider {
+    readonly daprPath: string;
     readonly daprdPath: string;
 }
 
 export default class VsCodeSettingsProvider implements SettingsProvider {
+    get daprPath(): string {
+        return this.getConfigurationValue('daprPath') || 'dapr';
+    }
+
     get daprdPath(): string {
+        return this.getConfigurationValue('daprdPath') || 'daprd';
+    }
+
+    private getConfigurationValue(name: string): string | undefined {
         const configuration = vscode.workspace.getConfiguration('vscode-dapr.configuration');
 
-        return configuration.get('daprdPath') || 'daprd';
+        return configuration.get(name);
     }
 }

--- a/src/services/settingsProvider.ts
+++ b/src/services/settingsProvider.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as vscode from 'vscode';
 
 export interface SettingsProvider {

--- a/src/tasks/daprCommandTaskProvider.ts
+++ b/src/tasks/daprCommandTaskProvider.ts
@@ -27,7 +27,7 @@ export interface DaprTaskDefinition extends TaskDefinition {
 }
 
 export default class DaprCommandTaskProvider extends CommandTaskProvider {
-    constructor(telemetryProvider: TelemetryProvider) {
+    constructor(daprPathProvider: () => string, telemetryProvider: TelemetryProvider) {
         super(
             (definition, callback) => {
                 return telemetryProvider.callWithTelemetry(
@@ -37,7 +37,7 @@ export default class DaprCommandTaskProvider extends CommandTaskProvider {
                         
                         const command =
                             CommandLineBuilder
-                                .create('dapr', 'run')
+                                .create(daprPathProvider(), 'run')
                                 .withNamedArg('--app-id', daprDefinition.appId)
                                 .withNamedArg('--app-max-concurrency', daprDefinition.appMaxConcurrency)
                                 .withNamedArg('--app-port', daprDefinition.appPort)

--- a/src/tasks/daprdCommandTaskProvider.ts
+++ b/src/tasks/daprdCommandTaskProvider.ts
@@ -40,6 +40,7 @@ export interface DaprdTaskDefinition extends TaskDefinition {
 
 export default class DaprdCommandTaskProvider extends CommandTaskProvider {
     constructor(
+        daprdPathProvider: () => string,
         environmentProvider: EnvironmentProvider,
         telemetryProvider: TelemetryProvider) {
         super(
@@ -51,7 +52,7 @@ export default class DaprdCommandTaskProvider extends CommandTaskProvider {
                         
                         const command =
                             CommandLineBuilder
-                                .create('daprd')
+                                .create(daprdPathProvider())
                                 .withNamedArg('--allowed-origins', daprDefinition.allowedOrigins)
                                 .withNamedArg('--app-id', daprDefinition.appId)
                                 .withNamedArg('--app-max-concurrency', daprDefinition.appMaxConcurrency)


### PR DESCRIPTION
Adds configuration settings for users with Dapr binaries not in the `PATH`.  Currently, the extension expected `dapr` and `daprd` to be in the `PATH`.  This is not always the case (and, sometimes, is non-intuitive as to how to add them to the "right" `PATH`).  In that case, users can now just set an explicit path to the binary.

Resolves #139.