### PR TITLE
Implemented issue #159 Dapr Dashboard

### DIFF
--- a/.devcontainer/library-scripts/azcli-debian.sh
+++ b/.devcontainer/library-scripts/azcli-debian.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/azcli.md
+# Maintainer: The VS Code and Codespaces Teams
+#
+# Syntax: ./azcli-debian.sh
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install curl, apt-transport-https, lsb-release, or gpg if missing
+if ! dpkg -s apt-transport-https curl ca-certificates lsb-release > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        apt-get update
+    fi
+    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates lsb-release gnupg2 
+fi
+
+# Install the Azure CLI
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
+curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+apt-get update
+apt-get install -y azure-cli
+echo "Done!"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,6 +23,18 @@
 			"presentation": {
 				"reveal": "never"
 			}
+		},
+		{
+			"appId": "app",
+			"appPort": 80,
+			"label": "daprd-debug",
+			"type": "daprd",
+			"dependsOn": "${defaultBuildTask}"
+		},
+		{
+			"appId": "app",
+			"label": "daprd-down",
+			"type": "daprd-down"
 		}
 	]
 }

--- a/i18n/jpn/package.i18n.json
+++ b/i18n/jpn/package.i18n.json
@@ -1,7 +1,6 @@
 {
 	"vscode-dapr.applications.invoke-get.title": "Invoke (GET) application method",
 	"vscode-dapr.applications.invoke-post.title": "Invoke (POST) application method",
-	"vscode-dapr.applications.openDaprDashboard.title": "Open Dapr Dashboard",
 	"vscode-dapr.applications.publish-message.title": "Publish message to application",
 	"vscode-dapr.applications.publish-all-message.title": "Publish Message to All Applications",
 	"vscode-dapr.help.readDocumentation.title": "Read Documentation",

--- a/i18n/jpn/package.i18n.json
+++ b/i18n/jpn/package.i18n.json
@@ -1,6 +1,7 @@
 {
 	"vscode-dapr.applications.invoke-get.title": "Invoke (GET) application method",
 	"vscode-dapr.applications.invoke-post.title": "Invoke (POST) application method",
+	"vscode-dapr.applications.openDaprDashboard.title": "Open Dapr Dashboard",
 	"vscode-dapr.applications.publish-message.title": "Publish message to application",
 	"vscode-dapr.applications.publish-all-message.title": "Publish Message to All Applications",
 	"vscode-dapr.help.readDocumentation.title": "Read Documentation",
@@ -8,6 +9,7 @@
 	"vscode-dapr.help.reportIssue.title": "Report Issue",
 	"vscode-dapr.help.reviewIssues.title": "Review Issues",
 	"vscode-dapr.tasks.scaffoldDaprTasks.title": "Scaffold Dapr Tasks",
+	"vscode-dapr.tasks.openDaprDashboard.title": "Open Dapr Dashboard",
 	"vscode-dapr.views.applications.name": "Applications",
 	"vscode-dapr.views.help.name": "Help and Feedback",
 	"vscode-dapr.tasks.dapr.properties.appId.description": "An ID for your application, used for service discovery.",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
 				"command": "vscode-dapr.tasks.openDaprDashboard",
 				"title": "%vscode-dapr.tasks.openDaprDashboard.title%",
 				"category": "Dapr",
-				"icon": "$(default-view-icon)"
+				"icon": "$(dashboard)"
 			}
 		],
 		"configuration": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"onCommand:vscode-dapr.tasks.scaffoldDaprComponents",
 		"onCommand:vscode-dapr.tasks.scaffoldDaprTasks",
 		"onCommand:workbench.action.tasks.runTask",
+		"onCommand:vscode-dapr.tasks.openDaprDashboard",
 		"onView:vscode-dapr.views.applications"
 	],
 	"repository": {
@@ -98,6 +99,12 @@
 				"command": "vscode-dapr.tasks.scaffoldDaprTasks",
 				"title": "%vscode-dapr.tasks.scaffoldDaprTasks.title%",
 				"category": "Dapr"
+			},
+			{
+				"command": "vscode-dapr.tasks.openDaprDashboard",
+				"title": "%vscode-dapr.tasks.openDaprDashboard.title%",
+				"category": "Dapr",
+				"icon": "$(default-view-icon)"
 			}
 		],
 		"configuration": {
@@ -131,6 +138,11 @@
 			"view/title": [
 				{
 					"command": "vscode-dapr.applications.publish-all-message",
+					"group": "navigation",
+					"when": "view == vscode-dapr.views.applications"
+				},
+				{
+					"command": "vscode-dapr.tasks.openDaprDashboard",
 					"group": "navigation",
 					"when": "view == vscode-dapr.views.applications"
 				}
@@ -470,6 +482,7 @@
 		"axios": "^0.21.1",
 		"fs-extra": "^9.1.0",
 		"handlebars": "^4.7.7",
+		"portfinder": "^1.0.28",
 		"ps-list": "^7.2.0",
 		"vscode-azureextensionui": "^0.40.0",
 		"vscode-nls": "^5.0.0"

--- a/package.nls.json
+++ b/package.nls.json
@@ -13,6 +13,7 @@
     "vscode-dapr.help.reviewIssues.title": "Review Issues",
     "vscode-dapr.tasks.scaffoldDaprComponents.title": "Scaffold Dapr Components",
     "vscode-dapr.tasks.scaffoldDaprTasks.title": "Scaffold Dapr Tasks",
+    "vscode-dapr.tasks.openDaprDashboard.title": "Open Dapr Dashboard",
     "vscode-dapr.views.applications.name": "Applications",
     "vscode-dapr.views.help.name": "Help and Feedback",
 

--- a/src/commands/openDaprDashboard.ts
+++ b/src/commands/openDaprDashboard.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import * as vscode from 'vscode';
-import DaprDashboardProvider from '../services/daprDashboardProvider';
+import ClassBasedDaprDashboardProvider from '../services/daprDashboardProvider';
 
 
-export async function openDaprDashboard( daprDashboardProvider: DaprDashboardProvider): Promise<void> {
+export async function openDaprDashboard( classBasedDaprDashboardProvider: ClassBasedDaprDashboardProvider): Promise<void> {
 
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    await vscode.env.openExternal(vscode.Uri.parse(`http://localhost:${daprDashboardProvider.getPortUsed()}`));
+    await vscode.env.openExternal(await classBasedDaprDashboardProvider.startDashboard());
 }
 
-const createOpenDaprDashboardCommand = ( daprDashboardProvider: DaprDashboardProvider) => (): Promise<void> => openDaprDashboard( daprDashboardProvider);
+const createOpenDaprDashboardCommand = ( classBasedDaprDashboardProvider: ClassBasedDaprDashboardProvider) => (): Promise<void> => openDaprDashboard( classBasedDaprDashboardProvider);
 export default createOpenDaprDashboardCommand;

--- a/src/commands/openDaprDashboard.ts
+++ b/src/commands/openDaprDashboard.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import * as vscode from 'vscode';
+import portfinder = require('portfinder');
+
+
+
+function ensureTerminalDoesNotExist(): boolean {
+    const terminals = <vscode.Terminal[]>(<any>vscode.window).terminals;
+    for (const terminal of terminals) {
+        if (terminal.name === 'Dapr Dashboard Terminal') {
+            vscode.window.showInformationMessage('Dapr Dashboard Terminal Already Exists');
+            return false;
+        }
+    }
+	return true;
+}
+
+export async function openDaprDashboard(): Promise<void> {
+    if (ensureTerminalDoesNotExist()){
+        const terminal = vscode.window.createTerminal(`Dapr Dashboard Terminal`);
+        await portfinder.getPortPromise()
+        .then((port) => {
+            const portUsed: number = port;
+            terminal.sendText(`dapr dashboard -p ${portUsed}`);
+            vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(`http://localhost:${portUsed}`));
+        })
+        .catch((err) => {
+            return Promise.reject(err);
+        });
+    }
+}
+
+const createOpenDaprDashboardCommand = () => (): Promise<void> => openDaprDashboard();
+export default createOpenDaprDashboardCommand;

--- a/src/commands/openDaprDashboard.ts
+++ b/src/commands/openDaprDashboard.ts
@@ -1,48 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import * as vscode from 'vscode';
-import portfinder = require('portfinder');
-import { spawn } from 'child_process';
-import createPlatformProcessProvider from '../services/processProvider';
+import DaprDashboardProvider from '../services/daprDashboardProvider';
 
 
-function getPortFromCommand(command: string): string {
-    if (command.includes('--port')){
-        command = command.split('--port')[1].toString().trim().split(" ")[0]
-    }
-    if (command.includes('-p') ){
-        command = command.split('-p')[1].toString().trim().split(" ")[0]
-    }
-    return command;
-}
-class ProcessBasedDaprDashboardProvider {
-    private processPlatform = createPlatformProcessProvider();
-    port:string | undefined;
+export async function openDaprDashboard( daprDashboardProvider: DaprDashboardProvider): Promise<void> {
 
-    async checkForDaprDashboard(): Promise<void> {
-        const dashboardProcesses = await this.processPlatform.listProcesses('dashboard');
-        if (dashboardProcesses.length > 0) {
-            this.port = getPortFromCommand(dashboardProcesses[0].cmd)
-        }
-    }
-}
-export async function openDaprDashboard(): Promise<void> {
-    const daprDashboardProvider = new ProcessBasedDaprDashboardProvider();
-
-    await daprDashboardProvider.checkForDaprDashboard();
-
-    if (daprDashboardProvider.port == undefined){
-        portfinder.getPortPromise()
-        .then((port) => {
-            spawn('dapr', ['dashboard', '-p', `${port}`]);
-            daprDashboardProvider.port = port.toString();
-        }) 
-        .catch((err) => {
-            console.log(err);
-        });    } 
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    await vscode.env.openExternal(vscode.Uri.parse(`http://localhost:${daprDashboardProvider.port}`));
+    await vscode.env.openExternal(vscode.Uri.parse(`http://localhost:${daprDashboardProvider.getPortUsed()}`));
 }
 
-const createOpenDaprDashboardCommand = () => (): Promise<void> => openDaprDashboard();
+const createOpenDaprDashboardCommand = ( daprDashboardProvider: DaprDashboardProvider) => (): Promise<void> => openDaprDashboard( daprDashboardProvider);
 export default createOpenDaprDashboardCommand;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import LocalScaffolder from './scaffolding/scaffolder';
 import NodeEnvironmentProvider from './services/environmentProvider';
 import createScaffoldDaprComponentsCommand from './commands/scaffoldDaprComponents';
 import VsCodeSettingsProvider from './services/settingsProvider';
+import DaprDashboardProvider from './services/daprDashboardProvider';
 
 export function activate(context: vscode.ExtensionContext): Promise<void> {
 	function registerDisposable<T extends vscode.Disposable>(disposable: T): T {
@@ -71,8 +72,10 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.help.reviewIssues', createReviewIssuesCommand(ui));
 			telemetryProvider.registerCommandWithTelemetry('vscode-dapr.tasks.scaffoldDaprComponents', createScaffoldDaprComponentsCommand(scaffolder, templateScaffolder));
 			telemetryProvider.registerCommandWithTelemetry('vscode-dapr.tasks.scaffoldDaprTasks', createScaffoldDaprTasksCommand(scaffolder, templateScaffolder, ui));
-			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.tasks.openDaprDashboard', createOpenDaprDashboardCommand());
 			const settingsProvider = new VsCodeSettingsProvider();
+
+			const daprDashboardProvider = new DaprDashboardProvider(settingsProvider.daprPath);
+			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.tasks.openDaprDashboard', createOpenDaprDashboardCommand(daprDashboardProvider));
 
 			registerDisposable(vscode.tasks.registerTaskProvider('dapr', new DaprCommandTaskProvider(() => settingsProvider.daprPath, telemetryProvider)));
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd', new DaprdCommandTaskProvider(() => settingsProvider.daprdPath, new NodeEnvironmentProvider(), telemetryProvider)));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import createReportIssueCommand from './commands/help/reportIssue';
 import createReviewIssuesCommand from './commands/help/reviewIssues';
 import createGetStartedCommand from './commands/help/getStarted';
 import createPlatformProcessProvider from './services/processProvider';
+import createOpenDaprDashboardCommand from './commands/openDaprDashboard';
 import LocalDaprInstallationManager from './services/daprInstallationManager';
 import HandlebarsTemplateScaffolder from './scaffolding/templateScaffolder';
 import LocalScaffolder from './scaffolding/scaffolder';
@@ -70,7 +71,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.help.reviewIssues', createReviewIssuesCommand(ui));
 			telemetryProvider.registerCommandWithTelemetry('vscode-dapr.tasks.scaffoldDaprComponents', createScaffoldDaprComponentsCommand(scaffolder, templateScaffolder));
 			telemetryProvider.registerCommandWithTelemetry('vscode-dapr.tasks.scaffoldDaprTasks', createScaffoldDaprTasksCommand(scaffolder, templateScaffolder, ui));
-			
+			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.tasks.openDaprDashboard', createOpenDaprDashboardCommand());
 			const settingsProvider = new VsCodeSettingsProvider();
 
 			registerDisposable(vscode.tasks.registerTaskProvider('dapr', new DaprCommandTaskProvider(() => settingsProvider.daprPath, telemetryProvider)));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ import NodeEnvironmentProvider from './services/environmentProvider';
 import createScaffoldDaprComponentsCommand from './commands/scaffoldDaprComponents';
 import VsCodeSettingsProvider from './services/settingsProvider';
 import DaprDashboardProvider from './services/daprDashboardProvider';
+import ClassBasedDaprDashboardProvider from './services/daprDashboardProvider';
 
 export function activate(context: vscode.ExtensionContext): Promise<void> {
 	function registerDisposable<T extends vscode.Disposable>(disposable: T): T {
@@ -74,8 +75,9 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			telemetryProvider.registerCommandWithTelemetry('vscode-dapr.tasks.scaffoldDaprTasks', createScaffoldDaprTasksCommand(scaffolder, templateScaffolder, ui));
 			const settingsProvider = new VsCodeSettingsProvider();
 
-			const daprDashboardProvider = new DaprDashboardProvider(settingsProvider.daprPath);
-			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.tasks.openDaprDashboard', createOpenDaprDashboardCommand(daprDashboardProvider));
+			const classBasedDaprDashboardProvider = new ClassBasedDaprDashboardProvider(settingsProvider.daprPath);
+			
+			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.tasks.openDaprDashboard', createOpenDaprDashboardCommand(classBasedDaprDashboardProvider));
 
 			registerDisposable(vscode.tasks.registerTaskProvider('dapr', new DaprCommandTaskProvider(() => settingsProvider.daprPath, telemetryProvider)));
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd', new DaprdCommandTaskProvider(() => settingsProvider.daprdPath, new NodeEnvironmentProvider(), telemetryProvider)));

--- a/src/services/daprDashboardProvider.ts
+++ b/src/services/daprDashboardProvider.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 import portfinder = require('portfinder');
 import { spawn } from 'child_process';
 

--- a/src/services/daprDashboardProvider.ts
+++ b/src/services/daprDashboardProvider.ts
@@ -1,0 +1,32 @@
+import portfinder = require('portfinder');
+import { spawn } from 'child_process';
+
+export default class DaprDashboardProvider {
+    private port:number | undefined;
+    private daprPath: string
+
+    constructor(daprPath: string) {
+        portfinder.getPortPromise()
+        .then((port) => {
+            this.port = port;
+        })
+        .then(() => {
+            this.spawnDashboardInstance()
+        })
+        .catch((err) => {
+            console.log(err);
+            this.port = 8080;
+            this.spawnDashboardInstance()
+        });
+        this.daprPath = daprPath;
+    }
+
+    spawnDashboardInstance(): void {
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        spawn(this.daprPath, ['dashboard', '-p', `${this.port}`]);
+    }
+
+    getPortUsed(): number | undefined {
+        return this.port;
+    }
+}

--- a/src/services/daprDashboardProvider.ts
+++ b/src/services/daprDashboardProvider.ts
@@ -1,34 +1,62 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import portfinder = require('portfinder');
-import { spawn } from 'child_process';
+import * as vscode from 'vscode';
+import {Process} from '../util/process'
+export interface DaprDashboardProvider {
+    startDashboard(): Promise<vscode.Uri>;
+}
 
-export default class DaprDashboardProvider {
+export default class ClassBasedDaprDashboardProvider implements DaprDashboardProvider {
     private port:number | undefined;
     private daprPath: string
-
+    private process = new Process();
     constructor(daprPath: string) {
-        portfinder.getPortPromise()
-        .then((port) => {
-            this.port = port;
-        })
-        .then(() => {
-            this.spawnDashboardInstance()
-        })
-        .catch((err) => {
-            console.log(err);
-            this.port = 8080;
-            this.spawnDashboardInstance()
-        });
         this.daprPath = daprPath;
     }
 
-    spawnDashboardInstance(): void {
+
+    async startDashboard(): Promise<vscode.Uri> {
+        await this.spawnDashboardInstance();
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        spawn(this.daprPath, ['dashboard', '-p', `${this.port}`]);
+        return vscode.Uri.parse(`http://localhost:${this.getPortUsed()}`)
     }
 
-    getPortUsed(): number | undefined {
+
+    async spawnDashboardInstance(): Promise<void>{
+        if (this.port != undefined) {
+            return;
+        }
+        await this.findOpenPort();
+        await this.processSpawn();
+    }
+
+    async findOpenPort(): Promise<void> {
+        await portfinder.getPortPromise()
+        .then((port) => {
+            this.port = port;
+        })
+        .catch((err) => {
+            console.log(err);
+            this.port = 50505;
+        });
+    }
+
+    async processSpawn() : Promise<void>{
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        await this.process.spawn(`${this.getDaprPath()} dashboard -p ${this.getPortUsed()}`)
+    }
+    
+
+    private getPortUsed(): number | undefined {
         return this.port;
+    }
+
+    setDaprPath(daprPath: string): void {
+        this.daprPath = daprPath;
+    }
+
+    getDaprPath(): string {
+        return this.daprPath;
     }
 }


### PR DESCRIPTION
## Issue


https://github.com/microsoft/vscode-dapr/issues/159

## Description


Added a tree view "Open Dapr Dashboard" command and a command palette "Open Dapr Dashboard" Command.

Command opens up a new terminal called "Dapr Dashboard Terminal", runs command "dapr dashboard -p ${port}" in where port is a unique open port. Command displays information message stating terminal already exists if terminal is still open and command and is run again.


## Tests

Tested out manually, both new UI icon displayed on "Applications" tree view and command palette.


## UI
<img width="432" alt="Screen Shot 2021-06-22 at 2 02 01 PM" src="https://user-images.githubusercontent.com/83607984/122976564-7f3ea600-d362-11eb-879e-890387739edf.png">
