### PR TITLE
Added Components Metadata #161

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,7 +80,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			registerDisposable(
 				vscode.window.registerTreeDataProvider(
 					'vscode-dapr.views.applications',
-					registerDisposable(new DaprApplicationTreeDataProvider(daprApplicationProvider, new LocalDaprInstallationManager()))));
+					registerDisposable(new DaprApplicationTreeDataProvider(daprApplicationProvider, new LocalDaprInstallationManager(), daprClient))));
 
 			registerDisposable(
 				vscode.window.registerTreeDataProvider(

--- a/src/services/daprClient.ts
+++ b/src/services/daprClient.ts
@@ -14,6 +14,7 @@ export interface DaprClient {
     invokeGet(application: DaprApplication, method: string, token?: vscode.CancellationToken): Promise<unknown>;
     invokePost(application: DaprApplication, method: string, payload?: unknown, token?: vscode.CancellationToken): Promise<unknown>;
     publishMessage(application: DaprApplication, pubSubName: string, topic: string, payload?: unknown, token?: vscode.CancellationToken): Promise<void>;
+    getMetadata(application: DaprApplication, token?: vscode.CancellationToken): Promise<DaprMetadata>;
 }
 
 function manageResponse(response: HttpResponse): unknown {
@@ -60,4 +61,22 @@ export default class HttpDaprClient implements DaprClient {
 
         await this.httpClient.post(url, payload, { json: true }, token);
     }
+
+    async getMetadata(application: DaprApplication, token?: vscode.CancellationToken | undefined): Promise<DaprMetadata>  {
+        const originalUrl = `http://localhost:${application.httpPort}/v1.0/metadata`;
+
+        const response = await this.httpClient.get(originalUrl, { allowRedirects: false }, token);
+        
+        return manageResponse(response) as DaprMetadata;
+    }
 }
+
+export interface DaprMetadata {
+    components: DaprComponentMetadata[];
+  }
+  
+  export interface DaprComponentMetadata {
+      name: string;
+      type: string;
+      version: string;
+  }

--- a/src/views/applications/daprApplicationNode.ts
+++ b/src/views/applications/daprApplicationNode.ts
@@ -5,9 +5,10 @@ import * as vscode from 'vscode';
 import TreeNode from "../treeNode";
 import { DaprApplication } from '../../services/daprApplicationProvider';
 import DaprComponentsNode from "./daprComponentsNode";
+import { DaprClient } from '../../services/daprClient';
 
 export default class DaprApplicationNode implements TreeNode {
-    constructor(public readonly application: DaprApplication) {
+    constructor(public readonly application: DaprApplication, public readonly daprClient: DaprClient) {
     }
 
     getTreeItem(): Promise<vscode.TreeItem> {
@@ -21,6 +22,6 @@ export default class DaprApplicationNode implements TreeNode {
     }
 
     getChildren(): TreeNode[] {
-        return [new DaprComponentsNode('Components', this.application)];
+        return [new DaprComponentsNode(this.application, this.daprClient)];
     }
 }

--- a/src/views/applications/daprApplicationNode.ts
+++ b/src/views/applications/daprApplicationNode.ts
@@ -4,18 +4,23 @@
 import * as vscode from 'vscode';
 import TreeNode from "../treeNode";
 import { DaprApplication } from '../../services/daprApplicationProvider';
+import DaprComponentsNode from "./daprComponentsNode";
 
 export default class DaprApplicationNode implements TreeNode {
     constructor(public readonly application: DaprApplication) {
     }
 
     getTreeItem(): Promise<vscode.TreeItem> {
-        const item = new vscode.TreeItem(this.application.appId);
+        const item = new vscode.TreeItem(this.application.appId, vscode.TreeItemCollapsibleState.Collapsed);
 
         item.contextValue = 'application';
 
         item.iconPath = new vscode.ThemeIcon('globe');
 
         return Promise.resolve(item);
+    }
+
+    getChildren(): TreeNode[] {
+        return [new DaprComponentsNode('Components', this.application)];
     }
 }

--- a/src/views/applications/daprApplicationTreeDataProvider.ts
+++ b/src/views/applications/daprApplicationTreeDataProvider.ts
@@ -34,13 +34,20 @@ export default class DaprApplicationTreeDataProvider extends vscode.Disposable i
         return element.getTreeItem();
     }
 
-    async getChildren(): Promise<TreeNode[]> {
-        const applications = await this.applicationProvider.getApplications();
-
-        if (applications.length > 0) {
-            return applications.map(application => new DaprApplicationNode(application));
+    async getChildren(element?: TreeNode): Promise<TreeNode[]> {
+        if (element) {
+            return element.getChildren?.() ?? [];
         } else {
-            return [ new NoApplicationsRunningNode(this.installationManager) ];
+            const applications = await this.applicationProvider.getApplications();
+            const appNodeList = applications.map(application => new DaprApplicationNode(application));
+ 
+
+            if (appNodeList.length > 0) {
+                return appNodeList;
+            } else {
+                return [ new NoApplicationsRunningNode(this.installationManager) ];
+            }
         }
+
     }
 }

--- a/src/views/applications/daprApplicationTreeDataProvider.ts
+++ b/src/views/applications/daprApplicationTreeDataProvider.ts
@@ -7,6 +7,7 @@ import TreeNode from '../treeNode';
 import DaprApplicationNode from './daprApplicationNode';
 import NoApplicationsRunningNode from './noApplicationsRunningNode';
 import { DaprInstallationManager } from '../../services/daprInstallationManager';
+import { DaprClient } from '../../services/daprClient';
 
 export default class DaprApplicationTreeDataProvider extends vscode.Disposable implements vscode.TreeDataProvider<TreeNode> {
     private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<TreeNode | null | undefined>();
@@ -14,7 +15,8 @@ export default class DaprApplicationTreeDataProvider extends vscode.Disposable i
 
     constructor(
         private readonly applicationProvider: DaprApplicationProvider,
-        private readonly installationManager: DaprInstallationManager) {
+        private readonly installationManager: DaprInstallationManager,
+        private readonly daprClient: DaprClient) {
         super(() => {
             this.applicationProviderListener.dispose();
             this.onDidChangeTreeDataEmitter.dispose();
@@ -39,7 +41,7 @@ export default class DaprApplicationTreeDataProvider extends vscode.Disposable i
             return element.getChildren?.() ?? [];
         } else {
             const applications = await this.applicationProvider.getApplications();
-            const appNodeList = applications.map(application => new DaprApplicationNode(application));
+            const appNodeList = applications.map(application => new DaprApplicationNode(application, this.daprClient));
  
 
             if (appNodeList.length > 0) {

--- a/src/views/applications/daprComponentsNode.ts
+++ b/src/views/applications/daprComponentsNode.ts
@@ -6,14 +6,14 @@ import * as nls from 'vscode-nls';
 import TreeNode from "../treeNode";
 import { DaprApplication } from '../../services/daprApplicationProvider';
 import DaprMetadataNode from './daprMetadataNode';
-import { DaprClient, DaprMetadata } from '../../services/daprClient';
+import { DaprClient } from '../../services/daprClient';
 import { getLocalizationPathForFile } from '../../util/localization';
 
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
 
 export default class DaprComponentsNode implements TreeNode {
-    constructor(public readonly application: DaprApplication, public readonly daprClient: DaprClient) {
+    constructor(private readonly application: DaprApplication, private readonly daprClient: DaprClient, private readonly token?: vscode.CancellationToken | undefined) {
     }
 
     getTreeItem(): Promise<vscode.TreeItem> {
@@ -30,18 +30,12 @@ export default class DaprComponentsNode implements TreeNode {
 
     async getChildren(): Promise<TreeNode[]> {
         const label = localize('views.applications.daprComponentsNode.noComponents', 'There are no components in use.');
-        const responseData = await this.getMetadata(this.application);
+        const responseData = await this.daprClient.getMetadata(this.application, this.token);
         const components = responseData.components;
         if(components.length > 0) {
             return components.map(comp => new DaprMetadataNode(comp.name, 'database'));
         }
         return [new DaprMetadataNode(label, 'warning')];
     }
-
-    private async getMetadata(application: DaprApplication, token?: vscode.CancellationToken | undefined): Promise<DaprMetadata>  {
-        //const daprClient = new HttpDaprClient(new AxiosHttpClient());
-        return await this.daprClient.getMetadata(application, token);
-    }
-    
 }
 

--- a/src/views/applications/daprComponentsNode.ts
+++ b/src/views/applications/daprComponentsNode.ts
@@ -13,7 +13,7 @@ const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
 
 export default class DaprComponentsNode implements TreeNode {
-    constructor(private readonly application: DaprApplication, private readonly daprClient: DaprClient, private readonly token?: vscode.CancellationToken | undefined) {
+    constructor(private readonly application: DaprApplication, private readonly daprClient: DaprClient) {
     }
 
     getTreeItem(): Promise<vscode.TreeItem> {
@@ -30,7 +30,7 @@ export default class DaprComponentsNode implements TreeNode {
 
     async getChildren(): Promise<TreeNode[]> {
         const label = localize('views.applications.daprComponentsNode.noComponents', 'There are no components in use.');
-        const responseData = await this.daprClient.getMetadata(this.application, this.token);
+        const responseData = await this.daprClient.getMetadata(this.application);
         const components = responseData.components;
         if(components.length > 0) {
             return components.map(comp => new DaprMetadataNode(comp.name, 'database'));

--- a/src/views/applications/daprComponentsNode.ts
+++ b/src/views/applications/daprComponentsNode.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+import TreeNode from "../treeNode";
+import { DaprApplication } from '../../services/daprApplicationProvider';
+import DaprMetadataNode from './daprMetadataNode';
+import AxiosHttpClient from '../../services/httpClient';
+import HttpDaprClient, { DaprMetadata } from '../../services/daprClient';
+
+
+export default class DaprComponentsNode implements TreeNode {
+    constructor(public readonly metadata: string, public readonly application: DaprApplication) {
+    }
+
+    getTreeItem(): Promise<vscode.TreeItem> {
+        const item = new vscode.TreeItem(this.metadata, vscode.TreeItemCollapsibleState.Collapsed);
+
+        item.contextValue = 'components';
+
+        item.iconPath = new vscode.ThemeIcon('archive');
+
+        return Promise.resolve(item);
+    }
+
+    async getChildren(): Promise<TreeNode[]> {
+        const responseData = await this.getMetadata(this.application);
+        const components = responseData.components;
+        return components.map(comp => new DaprMetadataNode(comp.name));
+    }
+
+    private async getMetadata(application: DaprApplication, token?: vscode.CancellationToken | undefined): Promise<DaprMetadata>  {
+        const daprClient = new HttpDaprClient(new AxiosHttpClient());
+        return await daprClient.getMetadata(application, token);
+    }
+    
+}
+

--- a/src/views/applications/daprMetadataNode.ts
+++ b/src/views/applications/daprMetadataNode.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import TreeNode from "../treeNode";
 
 export default class DaprMetadataNode implements TreeNode {
-    constructor(public readonly metadata: string) {
+    constructor(public readonly metadata: string, public readonly icon: string) {
     }
 
     getTreeItem(): Promise<vscode.TreeItem> {
@@ -13,7 +13,7 @@ export default class DaprMetadataNode implements TreeNode {
 
         item.contextValue = 'metadata';
 
-        item.iconPath = new vscode.ThemeIcon('database');
+        item.iconPath = new vscode.ThemeIcon(this.icon);
 
         return Promise.resolve(item);
     }

--- a/src/views/applications/daprMetadataNode.ts
+++ b/src/views/applications/daprMetadataNode.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+import TreeNode from "../treeNode";
+
+export default class DaprMetadataNode implements TreeNode {
+    constructor(public readonly metadata: string) {
+    }
+
+    getTreeItem(): Promise<vscode.TreeItem> {
+        const item = new vscode.TreeItem(this.metadata);
+
+        item.contextValue = 'metadata';
+
+        item.iconPath = new vscode.ThemeIcon('database');
+
+        return Promise.resolve(item);
+    }
+
+    
+}

--- a/src/views/applications/daprMetadataNode.ts
+++ b/src/views/applications/daprMetadataNode.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import TreeNode from "../treeNode";
 
 export default class DaprMetadataNode implements TreeNode {
-    constructor(public readonly metadata: string, public readonly icon: string) {
+    constructor(private readonly metadata: string, private readonly themeIconId: string) {
     }
 
     getTreeItem(): Promise<vscode.TreeItem> {
@@ -13,7 +13,7 @@ export default class DaprMetadataNode implements TreeNode {
 
         item.contextValue = 'metadata';
 
-        item.iconPath = new vscode.ThemeIcon(this.icon);
+        item.iconPath = new vscode.ThemeIcon(this.themeIconId);
 
         return Promise.resolve(item);
     }

--- a/src/views/treeNode.ts
+++ b/src/views/treeNode.ts
@@ -5,4 +5,5 @@ import * as vscode from 'vscode';
 
 export default interface TreeNode {
     getTreeItem(): Promise<vscode.TreeItem>;
+    getChildren?: () => TreeNode[] | Promise<TreeNode[]>;
 }


### PR DESCRIPTION
Added component metadata (name of component) to the application tree view. this addresses one aspect of issue #161 and addresses #167 that requests to expose more metadata. An example of the components view is shown below

<img width="259" alt="Screen Shot 2021-06-22 at 11 02 34 AM" src="https://user-images.githubusercontent.com/42750942/122960830-6b3a7a80-d349-11eb-9478-b30e99e5991f.png">
