### PR TITLE
Replace `wmic` with the PowerShell equivalent.

### DIFF
--- a/src/util/process.ts
+++ b/src/util/process.ts
@@ -8,7 +8,7 @@ import * as localization from './localization';
 
 const localize = nls.loadMessageBundle(localization.getLocalizationPathForFile(__filename));
 
-const DEFAULT_BUFFER_SIZE = 10 * 1024; // The default Node.js `exec` buffer size is 1 MB, our actual usage is far less
+const DEFAULT_BUFFER_SIZE = 24 * 1024; // The default Node.js `exec` buffer size is 1 MB, our actual usage is far less
 
 function bufferToString(buffer: Buffer): string {
     // Node.js treats null bytes as part of the length, which makes everything mad
@@ -69,7 +69,7 @@ export class Process extends vscode.Disposable {
 
                 // Without the shell option, it pukes on arguments
                 options = options || {};
-                options.shell = true;
+                options.shell ??= true;
 
                 const process = cp.spawn(command, options);
 


### PR DESCRIPTION
Replaces the Windows 11 deprecated `wmic.exe` with its PowerShell equivalent when retrieving processes on Windows.  

Mostly a port of [microsoft/vscode-tye#164](https://github.com/microsoft/vscode-tye/pull/164/files).

Resolves #205.