### PR TITLE
Extract default ASP.NET port from launch setting profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Change Log
 
-## v0.6.0 - 7 January 2022
+## v0.6.0 - 10 January 2022
 
 Minor bug fixes and dependency updates.
 
 ### Fixed
 
+* Fail to invoke the application method for a .NET 6 Web API project [#214](https://github.com/microsoft/vscode-dapr/issues/214)
 * Move to PowerShell-based WMI provider [#205](https://github.com/microsoft/vscode-dapr/issues/205)
 
 ## v0.5.0 - 6 August 2021

--- a/src/commands/scaffoldDaprTasks.ts
+++ b/src/commands/scaffoldDaprTasks.ts
@@ -58,15 +58,19 @@ async function getDefaultDotnetPort(folder: vscode.WorkspaceFolder | undefined):
                 const projectProfile = Object.values(launchSettingsJson.profiles).find(profile => profile.commandName === 'Project');
 
                 if (projectProfile?.applicationUrl) {
-                    try {
-                        const applicationUrl = new URL(projectProfile.applicationUrl);
-    
-                        if (applicationUrl.port) {
-                            return parseInt(applicationUrl.port, 10);
+                    const applicationUrls = projectProfile.applicationUrl.split(';');
+
+                    for (const applicationUrl of applicationUrls) {
+                        try {
+                            const url = new URL(applicationUrl);
+                            
+                            if (url.protocol === 'http' && url.port) {
+                                return parseInt(url.port, 10);
+                            }
                         }
-                    }
-                    catch {
-                        // NOTE: Ignore any errors parsing the URL.
+                        catch {
+                            // NOTE: Ignore any errors parsing the URL.
+                        }
                     }
                 }
             }

--- a/src/commands/scaffoldDaprTasks.ts
+++ b/src/commands/scaffoldDaprTasks.ts
@@ -34,40 +34,40 @@ const JavaPort = 8080;
 const NetCorePort = 5000;
 const NodePort = 3000;
 
-function getDefaultPort(configuration: DebugConfiguration | undefined): number {
+function getDefaultPort(configuration: DebugConfiguration | undefined): Promise<number> {
     switch (configuration?.type) {
         case 'coreclr':
-            return NetCorePort;
+            return Promise.resolve(NetCorePort);
 
         case 'java':
-            return JavaPort;
+            return Promise.resolve(JavaPort);
 
         case 'node':
         case 'node2':
         case 'pwa-node':
-            return NodePort;
+            return Promise.resolve(NodePort);
 
         case 'python':
             // "module": "flask" is a primary indicator of a Flask application...
             if (configuration?.module === 'flask') {
-                return FlaskPort;
+                return Promise.resolve(FlaskPort);
             }
 
             // "django": true is a primary indicator of a Django application...
             if (configuration?.django === true) {
-                return DjangoPort;
+                return Promise.resolve(DjangoPort);
             }
 
             // "jinja": true is a secondary indicator of a Flask application...
             if (configuration?.jinja === true) {
-                return FlaskPort;
+                return Promise.resolve(FlaskPort);
             }
 
             // Django seems to have a slight edge over Flask in popularity, so default to that...
-            return DjangoPort;
+            return Promise.resolve(DjangoPort);
     }
 
-    return DefaultPort;
+    return Promise.resolve(DefaultPort);
 }
 
 async function createUniqueName(prefix: string, isUnique: ConflictUniquenessPredicate): Promise<string> {
@@ -143,7 +143,7 @@ export async function scaffoldDaprTasks(context: IActionContext, scaffolder: Sca
         async wizardContext => {
             telemetryProperties.cancelStep = 'appPort';
 
-            const appPort = wizardContext.appPort ?? getDefaultPort(wizardContext.configuration);
+            const appPort = wizardContext.appPort ?? await getDefaultPort(wizardContext.configuration);
             
             const appPortString = await ui.showInputBox(
                 {

--- a/src/commands/scaffoldDaprTasks.ts
+++ b/src/commands/scaffoldDaprTasks.ts
@@ -49,8 +49,8 @@ async function getDefaultDotnetPort(folder: vscode.WorkspaceFolder | undefined):
     if (folder) {
         const launchSettingsFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(folder, "**/Properties/launchSettings.json"));
 
-        if (launchSettingsFiles.length > 0) {
-            const launchSettingsBuffer = await vscode.workspace.fs.readFile(launchSettingsFiles[0]);
+        for (const launchSettingsFile of launchSettingsFiles) {
+            const launchSettingsBuffer = await vscode.workspace.fs.readFile(launchSettingsFile);
             const launchSettingsContents = new TextDecoder('utf-8').decode(launchSettingsBuffer);
             const launchSettingsJson = JSON.parse(launchSettingsContents) as DotNetLaunchSettings;
 
@@ -64,7 +64,7 @@ async function getDefaultDotnetPort(folder: vscode.WorkspaceFolder | undefined):
                         try {
                             const url = new URL(applicationUrl);
                             
-                            if (url.protocol === 'http' && url.port) {
+                            if (url.protocol === 'http:' && url.port) {
                                 return parseInt(url.port, 10);
                             }
                         }


### PR DESCRIPTION
Starting with .NET 6, new ASP.NET applications are scaffolded to use a dynamically generated port, rather than `5000` used by earlier frameworks.  This change updates our default port logic to sniff the `launchSettings.json`, extracting the application URL for the "project" profile (i.e. the profile used by the Kestrel host, which is also now the default for ASP.NET applications), and using its port number as the default provided to the user.  (The user can, of course, overwrite that value with their own.)

Resolves #214.