### PR TITLE
Switch to `dapr` tasks by default.

### DIFF
--- a/src/commands/scaffoldDaprTasks.ts
+++ b/src/commands/scaffoldDaprTasks.ts
@@ -243,21 +243,21 @@ export async function scaffoldDaprTasks(context: IActionContext, scaffolder: Sca
         };
 
     const preLaunchTask = await scaffolder.scaffoldTask(
-        'daprd-debug',
+        'dapr-debug',
         result.folder,
         label => {
-            const daprdUpTask: DaprTaskDefinition = {
+            const daprUpTask: DaprTaskDefinition = {
                 appId: result.appId,
                 appPort: result.appPort,
                 label,
-                type: 'daprd'
+                type: 'dapr'
             };
         
             if (buildTask && buildTask !== label) {
-                daprdUpTask.dependsOn = buildTask;
+                daprUpTask.dependsOn = buildTask;
             }
 
-            return daprdUpTask;
+            return daprUpTask;
         },
         onTaskConflict);
 

--- a/src/tasks/daprCommandTaskProvider.ts
+++ b/src/tasks/daprCommandTaskProvider.ts
@@ -25,7 +25,7 @@ export interface DaprTaskDefinition extends TaskDefinition {
     logLevel?: 'debug' | 'info' | 'warning' | 'error' | 'fatal' | 'panic';
     placementHostAddress?: string;
     profilePort?: number;
-    type: 'daprd';
+    type: 'dapr';
 }
 
 export default class DaprCommandTaskProvider extends CommandTaskProvider {


### PR DESCRIPTION
When scaffolding tasks, scaffold the `dapr` task instead of the current `daprd`.  This uses the Dapr CLI directly rather than the underlying `daprd` CLI which better matches what users will do on their own on the command line.

> Note: the `daprd-down` task remains, as killing the underlying `daprd` process will be noticed by the parent `dapr` process and cause it to shutdown itself.

Resolves #74.