### PR TITLE
chore: change shut down daprd message

### DIFF
--- a/src/tasks/daprdDownTaskProvider.ts
+++ b/src/tasks/daprdDownTaskProvider.ts
@@ -34,7 +34,7 @@ export default class DaprdDownTaskProvider extends CustomExecutionTaskProvider {
                             .filter(application => application.appId === daprdDownDefinition.appId)
                             .forEach(application => process.kill(application.pid, 'SIGKILL'));
                         
-                        writer.writeLine(localize('tasks.daprdDownTaskProvider.shutdownMessage', 'Shutting down daprd...'));
+                        writer.writeLine(localize('tasks.daprdDownTaskProvider.shutdownMessage', 'daprd shut down complete'));
                     });
             },
             /* isBackgroundTask: */ false,


### PR DESCRIPTION
The log message here should tell user that the daprd shut down is complete, since the application process is killed in L35.  The original log "Shutting down daprd.." means it is still in progress.