### PR TITLE
Start Dapr run via Explorer View

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,11 @@
 				"icon": "$(debug-all)"
 			},
 			{
+				"command": "vscode-dapr.runs.start",
+				"title": "%vscode-dapr.runs.start.title%",
+				"category": "Dapr"
+			},
+			{
 				"command": "vscode-dapr.tasks.scaffoldDaprComponents",
 				"title": "%vscode-dapr.tasks.scaffoldDaprComponents.title%",
 				"category": "Dapr"
@@ -142,6 +147,16 @@
 				{
 					"command": "vscode-dapr.runs.debug",
 					"when": "never"
+				},
+				{
+					"command": "vscode-dapr.runs.start",
+					"when": "never"
+				}
+			],
+			"explorer/context": [
+				{
+					"command": "vscode-dapr.runs.start",
+					"when": "resourceFilename == dapr.yaml"
 				}
 			],
 			"view/item/context": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,6 +16,7 @@
     "vscode-dapr.help.reviewIssues.title": "Review Issues",
 
     "vscode-dapr.runs.debug.title": "Debug Run",
+    "vscode-dapr.runs.start.title": "Start Run",
 
     "vscode-dapr.tasks.scaffoldDaprComponents.title": "Scaffold Dapr Components",
     "vscode-dapr.tasks.scaffoldDaprTasks.title": "Scaffold Dapr Tasks",

--- a/src/commands/applications/startRun.ts
+++ b/src/commands/applications/startRun.ts
@@ -4,6 +4,7 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { getLocalizationPathForFile } from '../../util/localization';
 import * as nls from 'vscode-nls';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import DaprCommandTaskProvider, { DaprTaskDefinition } from '../../tasks/daprCommandTaskProvider';
 
@@ -15,11 +16,13 @@ export async function startRun(runTemplateFile: string, taskProvider: DaprComman
         runFile: runTemplateFile
     };
 
+    const runFileName = path.basename(path.dirname(runTemplateFile));
+
     const resolvedTask = await taskProvider.resolveTask(
         new vscode.Task(
             taskDefinition,
             vscode.TaskScope.Workspace,
-            "Run File",
+            runFileName,
             "Dapr"));
 
     if (!resolvedTask) {

--- a/src/commands/applications/startRun.ts
+++ b/src/commands/applications/startRun.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { getLocalizationPathForFile } from '../../util/localization';
+import * as nls from 'vscode-nls';
+import * as vscode from 'vscode';
+import DaprCommandTaskProvider, { DaprTaskDefinition } from '../../tasks/daprCommandTaskProvider';
+
+const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
+
+export async function startRun(runTemplateFile: string, taskProvider: DaprCommandTaskProvider): Promise<void> {
+    const taskDefinition: DaprTaskDefinition = {
+        type: 'dapr',
+        runFile: runTemplateFile
+    };
+
+    const resolvedTask = await taskProvider.resolveTask(
+        new vscode.Task(
+            taskDefinition,
+            vscode.TaskScope.Workspace,
+            "Run File",
+            "Dapr"));
+
+    if (!resolvedTask) {
+        throw new Error(localize('commands.applications.startRun.unresolvedTask', 'Unable to resolve a task for the dapr run.'));
+    }
+
+    await vscode.tasks.executeTask(resolvedTask);
+}
+
+const createStartRunCommand = (taskProvider: DaprCommandTaskProvider) => (context: IActionContext, uri: vscode.Uri): Promise<void> => {
+    const folder = vscode.workspace.workspaceFolders?.[0];
+
+    if (folder === undefined) {
+        throw new Error(localize('commands.applications.startRun.noWorkspaceFolder', 'Starting a Dapr run requires an open workspace.'));
+    }
+
+    return startRun(uri.fsPath, taskProvider);
+}
+
+export default createStartRunCommand;


### PR DESCRIPTION
Enables users to start a Dapr run via a context menu command on `dapr.yaml` files in the Explorer view.

<img width="432" alt="Screenshot 2023-02-08 at 23 07 42" src="https://user-images.githubusercontent.com/6402946/217742426-0f32e281-5a17-4e57-8d72-e9b9f4f45014.png">

Resolves #268