### PR TITLE
Add `dapr` debug configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"@opentelemetry/tracing": "^0.24.0",
 				"axios": "^0.27.2",
 				"handlebars": "^4.7.7",
+				"js-yaml": "^4.1.0",
 				"lodash.isequal": "^4.5.0",
 				"ps-list": "^8.1.1",
 				"rxjs": "^7.8.0",
@@ -24,6 +25,7 @@
 			"devDependencies": {
 				"@types/glob": "^7.2.0",
 				"@types/handlebars": "^4.1.0",
+				"@types/js-yaml": "^4.0.5",
 				"@types/lodash.isequal": "^4.5.6",
 				"@types/mocha": "^9.1.1",
 				"@types/node": "^16.11.38",
@@ -137,12 +139,6 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
-		},
 		"node_modules/@eslint/eslintrc/node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -158,18 +154,6 @@
 				"supports-color": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -493,6 +477,12 @@
 			"dependencies": {
 				"handlebars": "*"
 			}
+		},
+		"node_modules/@types/js-yaml": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+			"integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+			"dev": true
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.9",
@@ -1271,13 +1261,9 @@
 			"dev": true
 		},
 		"node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
@@ -2237,12 +2223,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/eslint/node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
-		},
 		"node_modules/eslint/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2363,18 +2343,6 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/eslint/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/espree": {
@@ -3332,13 +3300,11 @@
 			"dev": true
 		},
 		"node_modules/js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "^2.0.1"
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
@@ -3544,12 +3510,6 @@
 				"markdown-it": "bin/markdown-it.js"
 			}
 		},
-		"node_modules/markdown-it/node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
-		},
 		"node_modules/markdown-it/node_modules/entities": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
@@ -3731,12 +3691,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/mocha/node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
-		},
 		"node_modules/mocha/node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -3913,18 +3867,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/mocha/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/mocha/node_modules/minimatch": {
@@ -5011,7 +4953,7 @@
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"dev": true
 		},
 		"node_modules/stream-combiner": {
@@ -5430,6 +5372,15 @@
 				"node": ">=4.8.0"
 			}
 		},
+		"node_modules/tslint/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
 		"node_modules/tslint/node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5448,6 +5399,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/tslint/node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/tslint/node_modules/semver": {
@@ -6332,12 +6296,6 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"dependencies": {
-				"argparse": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-					"dev": true
-				},
 				"debug": {
 					"version": "4.3.4",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -6345,15 +6303,6 @@
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
-					}
-				},
-				"js-yaml": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-					"dev": true,
-					"requires": {
-						"argparse": "^2.0.1"
 					}
 				}
 			}
@@ -6633,6 +6582,12 @@
 			"requires": {
 				"handlebars": "*"
 			}
+		},
+		"@types/js-yaml": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+			"integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+			"dev": true
 		},
 		"@types/json-schema": {
 			"version": "7.0.9",
@@ -7250,13 +7205,9 @@
 			"dev": true
 		},
 		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"requires": {
-				"sprintf-js": "~1.0.2"
-			}
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
 		"array-union": {
 			"version": "2.1.0",
@@ -8020,12 +7971,6 @@
 						"color-convert": "^2.0.1"
 					}
 				},
-				"argparse": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-					"dev": true
-				},
 				"chalk": {
 					"version": "4.1.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8114,15 +8059,6 @@
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.3"
-					}
-				},
-				"js-yaml": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-					"dev": true,
-					"requires": {
-						"argparse": "^2.0.1"
 					}
 				}
 			}
@@ -8881,13 +8817,11 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "^2.0.1"
 			}
 		},
 		"json-parse-even-better-errors": {
@@ -9059,12 +8993,6 @@
 				"uc.micro": "^1.0.5"
 			},
 			"dependencies": {
-				"argparse": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-					"dev": true
-				},
 				"entities": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
@@ -9201,12 +9129,6 @@
 						"picomatch": "^2.0.4"
 					}
 				},
-				"argparse": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-					"dev": true
-				},
 				"binary-extensions": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -9335,15 +9257,6 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
-				},
-				"js-yaml": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-					"dev": true,
-					"requires": {
-						"argparse": "^2.0.1"
-					}
 				},
 				"minimatch": {
 					"version": "5.0.1",
@@ -10194,7 +10107,7 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"dev": true
 		},
 		"stream-combiner": {
@@ -10510,6 +10423,15 @@
 				"tsutils": "^2.29.0"
 			},
 			"dependencies": {
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
 				"glob": {
 					"version": "7.2.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -10522,6 +10444,16 @@
 						"minimatch": "^3.1.1",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
 					}
 				},
 				"semver": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"kubernetes"
 	],
 	"activationEvents": [
+		"onDebugResolve:dapr",
 		"onTaskType:dapr",
 		"onTaskType:daprd"
 	],
@@ -144,6 +145,22 @@
 				}
 			}
 		},
+		"debuggers": [
+			{
+				"type": "dapr",
+				"configurationAttributes": {
+					"launch": {
+						"properties": {
+							"runFile": {
+								"type": "string",
+								"description": "%vscode-dapr.debuggers.dapr.properties.runFile.description%"
+							}
+						},
+						"required": ["runFile"]
+					}
+				}
+			}
+		],
 		"menus": {
 			"commandPalette": [
 				{
@@ -660,6 +677,7 @@
 	"devDependencies": {
 		"@types/glob": "^7.2.0",
 		"@types/handlebars": "^4.1.0",
+		"@types/js-yaml": "^4.0.5",
 		"@types/lodash.isequal": "^4.5.6",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^16.11.38",
@@ -690,6 +708,7 @@
 		"@opentelemetry/tracing": "^0.24.0",
 		"axios": "^0.27.2",
 		"handlebars": "^4.7.7",
+		"js-yaml": "^4.1.0",
 		"lodash.isequal": "^4.5.0",
 		"ps-list": "^8.1.1",
 		"rxjs": "^7.8.0",

--- a/package.json
+++ b/package.json
@@ -151,12 +151,29 @@
 				"configurationAttributes": {
 					"launch": {
 						"properties": {
+							"excludeApps": {
+								"type": "array",
+								"description": "%vscode-dapr.debuggers.dapr.properties.excludeApps.description%",
+								"items": {
+									"type": "string"
+								}
+							},
+							"includeApps": {
+								"type": "array",
+								"description": "%vscode-dapr.debuggers.dapr.properties.includeApps.description%",
+								"items": {
+									"type": "string"
+								}
+							},
 							"runFile": {
 								"type": "string",
 								"description": "%vscode-dapr.debuggers.dapr.properties.runFile.description%"
 							}
 						},
-						"required": ["runFile"]
+						"required": ["runFile"],
+						"not": {
+							"required": ["excludeApps", "includeApps"]
+						}
 					}
 				}
 			}

--- a/package.nls.json
+++ b/package.nls.json
@@ -9,6 +9,8 @@
     "vscode-dapr.configuration.paths.daprPath.description": "The full path to the dapr binary.",
     "vscode-dapr.configuration.paths.daprdPath.description": "The full path to the daprd binary.",
 
+    "vscode-dapr.debuggers.dapr.properties.runFile.description": "Path to the run template file for the list of apps to run.",
+
     "vscode-dapr.help.readDocumentation.title": "Read Documentation",
     "vscode-dapr.help.getStarted.title": "Get Started",
     "vscode-dapr.help.installDapr.title": "Install Dapr",

--- a/package.nls.json
+++ b/package.nls.json
@@ -9,6 +9,8 @@
     "vscode-dapr.configuration.paths.daprPath.description": "The full path to the dapr binary.",
     "vscode-dapr.configuration.paths.daprdPath.description": "The full path to the daprd binary.",
 
+    "vscode-dapr.debuggers.dapr.properties.excludeApps.description": "If specified, all applications but these (by ID) from the run file will be debugged.",
+    "vscode-dapr.debuggers.dapr.properties.includeApps.description": "If specified, only these applications (by ID) from the run file will be debugged.",
     "vscode-dapr.debuggers.dapr.properties.runFile.description": "Path to the run template file for the list of apps to run.",
 
     "vscode-dapr.help.readDocumentation.title": "Read Documentation",

--- a/src/debug/daprDebugConfigurationProvider.ts
+++ b/src/debug/daprDebugConfigurationProvider.ts
@@ -4,9 +4,12 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { load } from 'js-yaml';
 import { getLocalizationPathForFile } from '../util/localization';
-import { DaprApplicationProvider } from '../services/daprApplicationProvider';
-import { filter, map, switchMap, takeWhile } from 'rxjs';
+import { DaprApplication, DaprApplicationProvider } from '../services/daprApplicationProvider';
+import { filter, first, firstValueFrom, map, race, timeout } from 'rxjs';
 import { debugApplication } from '../commands/applications/debugApplication';
+import { UserInput } from '../services/userInput';
+import { withAggregateTokens } from '../util/aggregateCancellationTokenSource';
+import { fromCancellationToken } from '../util/observableCancellationToken';
 
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
@@ -36,58 +39,77 @@ function getAppId(app: DaprRunApplication): string {
 }
 
 export class DaprDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
-    constructor(private readonly daprApplicationProvider: DaprApplicationProvider) {
+    constructor(
+        private readonly daprApplicationProvider: DaprApplicationProvider,
+        private readonly userInput: UserInput) {
     }
 
-    async resolveDebugConfigurationWithSubstitutedVariables?(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | undefined> {
+    async resolveDebugConfigurationWithSubstitutedVariables?(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, debugToken?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | undefined> {
         const daprDebugConfiguration = <DaprDebugConfiguration>debugConfiguration;
 
         const runFileContent = await fs.readFile(daprDebugConfiguration.runFile, { encoding: 'utf8' });
+
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         const runFile = load(runFileContent) as DaprRunFile;
 
         const appIds = new Set<string>(runFile.apps?.map(getAppId) ?? []);
 
-        await new Promise<void>(
-            (resolve, reject) => {
-                const subscription =
-                    this.daprApplicationProvider
-                        .applications
-                        .pipe(
-                            // Include only those applications that are part of the run...
-                            map(apps => apps.filter(app => app.runTemplatePath === daprDebugConfiguration.runFile)),
-                            // Include only those applications that are running...
-                            map(apps => apps.filter(app => app.appPid !== 0)),
-                            // Include only those applications remaining to be attached...
-                            map(apps => apps.filter(app => appIds.has(app.appId))),
-                            // Ignore empty set...
-                            filter(apps => apps.length > 0),
-                            // Attach to apps not yet attached...
-                            switchMap(
-                                async apps => {
-                                    for (const app of apps) {
-                                        // TODO: Catch errors to keep trying...
-                                        await debugApplication(app);
+        await this.userInput.withProgress(
+            localize('debug.daprDebugConfigurationProvider.attachingProgress', 'Attaching to Dapr applications...'),
+            (process, userToken) => withAggregateTokens(token => this.attachToApplications(daprDebugConfiguration.runFile, appIds, token), userToken, debugToken));
 
-                                        appIds.delete(app.appId);
-                                    }
-                                }))
-                        .subscribe(
-                            {
-                                next: () => {
-                                    if (appIds.size === 0) {
-                                        subscription.unsubscribe();
-                                        resolve();
-                                        }
-                                },
-                                error: error => reject(error),
-                                complete: () => {
-                                    subscription.unsubscribe();
-                                    resolve();
-                                }
-                            });
-            })
-            
         return undefined;
+    }
+
+    private async attachToApplications(runFile: string, appIds: Set<string>, token: vscode.CancellationToken): Promise<void> {
+        const applications = await this.waitForApplications(runFile, appIds, token);
+
+        await this.waitForAttach(applications, token);
+    }
+
+    private async waitForApplications(runFile: string, appIds: Set<string>, token: vscode.CancellationToken): Promise<DaprApplication[]> {
+        const applicationMonitor = this.daprApplicationProvider
+            .applications
+            .pipe(
+                // Include only those applications that are part of the run...
+                map(apps => apps.filter(app => app.runTemplatePath === runFile)),
+                // Include only those applications that are running...
+                map(apps => apps.filter(app => app.appPid !== 0)),
+                // Include only those applications to be attached...
+                map(apps => apps.filter(app => appIds.has(app.appId))),
+                // Notify only when all services are running...
+                filter(apps => apps.length === appIds.size),
+                // Complete on the first notification (of all services running)...
+                first(),
+                // Ultimately timeout after 1 min...
+                timeout(60000));
+
+        // Wait either for all applications running, or the user cancels, or eventually times out...
+        const applications =
+            await firstValueFrom(
+                race(
+                    applicationMonitor,
+                    fromCancellationToken(token)));
+
+        //
+        // NOTE: Applications should always be valid (as otherwise an exception would have been raised).
+        //
+
+        if (!applications) {
+            throw new Error(localize('debug.daprDebugConfigurationProvider.noApplicationsRunning', 'No applications were found to be running.'));
+        }
+
+        return applications;
+    }
+
+    private async waitForAttach(applications: DaprApplication[], token: vscode.CancellationToken) {
+        for (const application of applications) {
+            if (token.isCancellationRequested) {
+                break;
+            }
+
+            // TODO: Catch errors to keep trying...
+            await debugApplication(application);
+        }
     }
 }

--- a/src/debug/daprDebugConfigurationProvider.ts
+++ b/src/debug/daprDebugConfigurationProvider.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs/promises';
+import * as nls from 'vscode-nls';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { load } from 'js-yaml';
+import { getLocalizationPathForFile } from '../util/localization';
+import { DaprApplicationProvider } from '../services/daprApplicationProvider';
+import { filter, map, switchMap, takeWhile } from 'rxjs';
+import { debugApplication } from '../commands/applications/debugApplication';
+
+const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
+
+export interface DaprDebugConfiguration extends vscode.DebugConfiguration {
+    runFile: string;
+}
+
+interface DaprRunApplication {
+    appDirPath?: string;
+    appID?: string;
+}
+
+interface DaprRunFile {
+    apps?: DaprRunApplication[];
+}
+
+function getAppId(app: DaprRunApplication): string {
+    if (app.appID) {
+        return app.appID;
+    }
+
+    if (app.appDirPath) {
+        return path.basename(app.appDirPath);
+    }
+
+    throw new Error(localize('debug.daprDebugConfigurationProvider.unableToDetermineAppId', 'Unable to determine a configured application\'s ID.'));
+}
+
+export class DaprDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+    constructor(private readonly daprApplicationProvider: DaprApplicationProvider) {
+    }
+
+    async resolveDebugConfigurationWithSubstitutedVariables?(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | undefined> {
+        const daprDebugConfiguration = <DaprDebugConfiguration>debugConfiguration;
+
+        const runFileContent = await fs.readFile(daprDebugConfiguration.runFile, { encoding: 'utf8' });
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        const runFile = load(runFileContent) as DaprRunFile;
+
+        const appIds = new Set<string>(runFile.apps?.map(getAppId) ?? []);
+
+        await new Promise<void>(
+            (resolve, reject) => {
+                const subscription =
+                    this.daprApplicationProvider
+                        .applications
+                        .pipe(
+                            // Include only those applications that are part of the run...
+                            map(apps => apps.filter(app => app.runTemplatePath === daprDebugConfiguration.runFile)),
+                            // Include only those applications that are running...
+                            map(apps => apps.filter(app => app.appPid !== 0)),
+                            // Include only those applications remaining to be attached...
+                            map(apps => apps.filter(app => appIds.has(app.appId))),
+                            // Ignore empty set...
+                            filter(apps => apps.length > 0),
+                            // Attach to apps not yet attached...
+                            switchMap(
+                                async apps => {
+                                    for (const app of apps) {
+                                        // TODO: Catch errors to keep trying...
+                                        await debugApplication(app);
+
+                                        appIds.delete(app.appId);
+                                    }
+                                }))
+                        .subscribe(
+                            {
+                                next: () => {
+                                    if (appIds.size === 0) {
+                                        subscription.unsubscribe();
+                                        resolve();
+                                        }
+                                },
+                                error: error => reject(error),
+                                complete: () => {
+                                    subscription.unsubscribe();
+                                    resolve();
+                                }
+                            });
+            })
+            
+        return undefined;
+    }
+}

--- a/src/debug/daprDebugConfigurationProvider.ts
+++ b/src/debug/daprDebugConfigurationProvider.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as fs from 'fs/promises';
 import * as nls from 'vscode-nls';
 import * as path from 'path';
@@ -123,13 +126,22 @@ export class DaprDebugConfigurationProvider implements vscode.DebugConfiguration
     }
 
     private async waitForAttach(applications: DaprApplication[], token: vscode.CancellationToken) {
+        let hadFailures = false;
+
         for (const application of applications) {
             if (token.isCancellationRequested) {
                 break;
             }
 
-            // TODO: Catch errors to keep trying...
-            await debugApplication(application);
+            try {
+                await debugApplication(application);
+            } catch {
+                hadFailures = true;
+            }
+        }
+
+        if (hadFailures) {
+            throw new Error(localize('debug.daprDebugConfigurationProvider.hadFailures', 'The debugger failed to attach to all applications.'));
         }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,7 @@ import createDebugRunCommand from './commands/applications/debugRun';
 import { AsyncDisposable } from './util/asyncDisposable';
 import createStartRunCommand from './commands/applications/startRun';
 import createStopRunCommand from './commands/applications/stopRun';
+import { DaprDebugConfigurationProvider } from './debug/daprDebugConfigurationProvider';
 
 interface ExtensionPackage {
 	engines: { [key: string]: string };
@@ -117,6 +118,8 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd', new DaprdCommandTaskProvider(daprInstallationManager, () => settingsProvider.daprdPath, new NodeEnvironmentProvider(), telemetryProvider)));
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd-down', new DaprdDownTaskProvider(daprApplicationProvider, telemetryProvider)));
 			
+			registerDisposable(vscode.debug.registerDebugConfigurationProvider('dapr', new DaprDebugConfigurationProvider(daprApplicationProvider)));
+
 			const applicationsTreeView = registerDisposable(
 				vscode.window.createTreeView(
 					'vscode-dapr.views.applications',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,7 +118,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd', new DaprdCommandTaskProvider(daprInstallationManager, () => settingsProvider.daprdPath, new NodeEnvironmentProvider(), telemetryProvider)));
 			registerDisposable(vscode.tasks.registerTaskProvider('daprd-down', new DaprdDownTaskProvider(daprApplicationProvider, telemetryProvider)));
 			
-			registerDisposable(vscode.debug.registerDebugConfigurationProvider('dapr', new DaprDebugConfigurationProvider(daprApplicationProvider)));
+			registerDisposable(vscode.debug.registerDebugConfigurationProvider('dapr', new DaprDebugConfigurationProvider(daprApplicationProvider, ui)));
 
 			const applicationsTreeView = registerDisposable(
 				vscode.window.createTreeView(

--- a/src/util/aggregateCancellationTokenSource.ts
+++ b/src/util/aggregateCancellationTokenSource.ts
@@ -1,0 +1,28 @@
+import * as vscode from 'vscode';
+
+export async function withAggregateTokens<T>(callback: (token: vscode.CancellationToken) => Promise<T>, ...tokens: (vscode.CancellationToken | undefined)[]): Promise<T> {
+    const cancellationTokenSource = new AggregateCancellationTokenSource(...tokens);
+    try {
+        return await callback(cancellationTokenSource.token);
+    } finally {
+        cancellationTokenSource.dispose();
+    }
+}
+
+export default class AggregateCancellationTokenSource extends vscode.CancellationTokenSource {
+    private readonly listeners: (vscode.Disposable | undefined)[];
+
+    constructor(...tokens: (vscode.CancellationToken | undefined)[]) {
+        super();
+
+        this.listeners = tokens.map(token => token?.onCancellationRequested(() => this.cancel()));
+    }
+
+    dispose() {
+        for (const listener of this.listeners) {
+            listener?.dispose();
+        }
+
+        super.dispose();
+    }
+}

--- a/src/util/aggregateCancellationTokenSource.ts
+++ b/src/util/aggregateCancellationTokenSource.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as vscode from 'vscode';
 
 export async function withAggregateTokens<T>(callback: (token: vscode.CancellationToken) => Promise<T>, ...tokens: (vscode.CancellationToken | undefined)[]): Promise<T> {

--- a/src/util/observableCancellationToken.ts
+++ b/src/util/observableCancellationToken.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+import { Observable } from 'rxjs';
+import * as nls from 'vscode-nls';
+import { getLocalizationPathForFile } from './localization';
+
+const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
+
+export function fromCancellationToken(cancellationToken: vscode.CancellationToken): Observable<void> {
+    return new Observable<void>(
+        subscriber => {
+            const listener = cancellationToken.onCancellationRequested(
+                () => {
+                    subscriber.error(new Error(localize('util.observableCancellationToken.cancellationRequested', 'Cancellation was requested.')));
+                });
+
+            return () => {
+                listener.dispose()
+            };
+        });
+}

--- a/src/util/process.ts
+++ b/src/util/process.ts
@@ -155,7 +155,7 @@ export class Process {
                     const tokenListener = token.onCancellationRequested(
                         () => {
                             if (process.pid !== undefined) {
-                                process.kill();
+                                void treeKill(process.pid);
                             }
 
                             tokenListener.dispose();


### PR DESCRIPTION
Adds a custom `dapr` debug configuration that enables F5-style debugging of Dapr applications, simply by pointing to the `dapr.yaml` run file.  Developers can debug existing Dapr applications or, via the `preLaunchTask` property, make the startup of the applications (e.g. via a `dapr` task) a prerequisite.  Developers can also indicate that only a subset of the applications in the run file should be attached to (either via an inclusion or exclusion list, using the `includeApps` and `excludeApps` properties, respectfully).

```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Launch Dapr",
            "request": "launch",
            "type": "dapr",
            "runFile": "${workspaceFolder}/dapr.yaml",
            // "includeApps": ["csharp-subscriber", "node-subscriber"],
            // "excludeApps": ["python-subscriber", "react-form"],
            "preLaunchTask": "dapr"
        }
    ]
}
```

Resolves #273 