### PR TITLE
Show run file application logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,16 @@
 				"category": "Dapr"
 			},
 			{
+				"command": "vscode-dapr.applications.view-app-logs",
+				"title": "%vscode-dapr.applications.view-app-logs.title%",
+				"category": "Dapr"
+			},
+			{
+				"command": "vscode-dapr.applications.view-dapr-logs",
+				"title": "%vscode-dapr.applications.view-dapr-logs.title%",
+				"category": "Dapr"
+			},
+			{
 				"command": "vscode-dapr.help.getStarted",
 				"title": "%vscode-dapr.help.getStarted.title%",
 				"category": "Dapr"
@@ -185,6 +195,14 @@
 					"when": "never"
 				},
 				{
+					"command": "vscode-dapr.applications.view-app-logs",
+					"when": "never"
+				},
+				{
+					"command": "vscode-dapr.applications.view-dapr-logs",
+					"when": "never"
+				},
+				{
 					"command": "vscode-dapr.runs.debug",
 					"when": "never"
 				},
@@ -228,6 +246,16 @@
 					"command": "vscode-dapr.applications.stop-app",
 					"when": "view == vscode-dapr.views.applications && viewItem =~ /application/",
 					"group": "stop"
+				},
+				{
+					"command": "vscode-dapr.applications.view-app-logs",
+					"when": "view == vscode-dapr.views.applications && viewItem =~ /application/ && viewItem =~ /hasLogs/",
+					"group": "logs"
+				},
+				{
+					"command": "vscode-dapr.applications.view-dapr-logs",
+					"when": "view == vscode-dapr.views.applications && viewItem =~ /application/ && viewItem =~ /hasLogs/",
+					"group": "logs"
 				},
 				{
 					"command": "vscode-dapr.runs.debug",

--- a/package.nls.json
+++ b/package.nls.json
@@ -5,6 +5,8 @@
     "vscode-dapr.applications.publish-message.title": "Publish Message to Application",
     "vscode-dapr.applications.publish-all-message.title": "Publish Message to All Applications",
     "vscode-dapr.applications.stop-app.title": "Stop Application",
+    "vscode-dapr.applications.view-app-logs.title": "View Application Logs",
+    "vscode-dapr.applications.view-dapr-logs.title": "View Dapr Logs",
 
     "vscode-dapr.configuration.paths.daprPath.description": "The full path to the dapr binary.",
     "vscode-dapr.configuration.paths.daprdPath.description": "The full path to the daprd binary.",

--- a/src/commands/applications/debugApplication.ts
+++ b/src/commands/applications/debugApplication.ts
@@ -109,7 +109,7 @@ export async function debugApplication(application: DaprApplication): Promise<vo
 
 const createDebugApplicationCommand = () => (context: IActionContext, node: DaprApplicationNode | undefined): Promise<void> => {
     if (node == undefined) {
-        throw new Error(localize('commands.applications.debugApplication.noPaletteSupport', 'Debugging requires selecting an application in the Dapr view.'));
+        throw new Error(localize('commands.applications.viewLogs.noPaletteSupport', 'Debugging requires selecting an application in the Dapr view.'));
     }
 
     return debugApplication(node.application);

--- a/src/commands/applications/viewAppLogs.ts
+++ b/src/commands/applications/viewAppLogs.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import DaprApplicationNode from "../../views/applications/daprApplicationNode";
+import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { getLocalizationPathForFile } from '../../util/localization';
+import * as nls from 'vscode-nls';
+import { DaprApplication } from "../../services/daprApplicationProvider";
+
+const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
+
+export async function viewAppLogs(application: DaprApplication): Promise<void> {
+    await Promise.resolve();
+}
+
+const createViewAppLogsCommand = () => (context: IActionContext, node: DaprApplicationNode | undefined): Promise<void> => {
+    if (node == undefined) {
+        throw new Error(localize('commands.applications.viewAppLogs.noPaletteSupport', 'Viewing logs requires selecting an application in the Dapr view.'));
+    }
+
+    return viewAppLogs(node.application);
+}
+
+export default createViewAppLogsCommand;

--- a/src/commands/applications/viewAppLogs.ts
+++ b/src/commands/applications/viewAppLogs.ts
@@ -2,57 +2,19 @@
 // Licensed under the MIT license.
 
 import * as nls from 'vscode-nls';
-import * as path from 'path';
-import * as vscode from 'vscode';
 import DaprApplicationNode from "../../views/applications/daprApplicationNode";
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { getLocalizationPathForFile } from '../../util/localization';
-import { DaprApplication } from "../../services/daprApplicationProvider";
-import { fromRunFilePath, getAppId } from "../../util/runFileReader";
+import { viewLogs } from './viewLogs';
 
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
-export async function viewAppLogs(application: DaprApplication): Promise<void> {
-    if (!application.runTemplatePath) {
-        throw new Error(localize('commands.applications.viewAppLogs.noRunFile', 'Logs can be viewed only when applications are started via a run file.'));
-    }
-
-    const runFile = await fromRunFilePath(application.runTemplatePath);
-
-    const runFileApplication = (runFile.apps ?? []).find(app => application.appId === getAppId(app));
-
-    if (!runFileApplication) {
-        throw new Error(localize('commands.applications.viewAppLogs.appNotFound', 'The application \'{0}\' was not found in the run file \'{1}\'.', application.appId, application.runTemplatePath));
-    }
-
-    if (!runFileApplication.appDirPath) {
-        throw new Error(localize('commands.applications.viewAppLogs.appDirNotFound', 'The directory for application \'{0}\' was not found in the run file \'{1}\'.', application.appId, application.runTemplatePath));
-    }
-
-    const runFileDirectory = path.dirname(application.runTemplatePath);
-    const appDirectory = path.join(runFileDirectory, runFileApplication.appDirPath, '.dapr', 'logs');
-
-    const pattern = `${application.appId}_app_*.log`;
-    const relativePattern = new vscode.RelativePattern(appDirectory, pattern);
-
-    const files = await vscode.workspace.findFiles(relativePattern);
-
-    if (files.length === 0) {
-        throw new Error(localize('commands.applications.viewAppLogs.logNotFound', 'No logs for application \'{0}\' were found.', application.appId));
-    }
-
-    const newestFile = files.reduce((newestFile, nextFile) => newestFile.fsPath.localeCompare(nextFile.fsPath) < 0 ? nextFile : newestFile);
-
-    // TODO: Scroll to end.
-    await vscode.window.showTextDocument(newestFile);
-}
-
 const createViewAppLogsCommand = () => (context: IActionContext, node: DaprApplicationNode | undefined): Promise<void> => {
     if (node == undefined) {
-        throw new Error(localize('commands.applications.viewAppLogs.noPaletteSupport', 'Viewing logs requires selecting an application in the Dapr view.'));
+        throw new Error(localize('commands.applications.viewAppLogs.noPaletteSupport', 'Viewing application logs requires selecting an application in the Dapr view.'));
     }
 
-    return viewAppLogs(node.application);
+    return viewLogs(node.application, 'app');
 }
 
 export default createViewAppLogsCommand;

--- a/src/commands/applications/viewAppLogs.ts
+++ b/src/commands/applications/viewAppLogs.ts
@@ -5,12 +5,64 @@ import DaprApplicationNode from "../../views/applications/daprApplicationNode";
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { getLocalizationPathForFile } from '../../util/localization';
 import * as nls from 'vscode-nls';
+import * as path from 'path';
+import * as vscode from 'vscode';
 import { DaprApplication } from "../../services/daprApplicationProvider";
+import { fromRunFilePath, getAppId } from "../../util/runFileReader";
 
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
+function getTimestamp(file: vscode.Uri): string {
+    const filePath = file.fsPath;
+    const fileName = path.basename(filePath);
+
+    const splitFileName = fileName.split('_');
+
+    if (splitFileName.length < 3) {
+        throw new Error(localize('commands.applications.viewAppLogs.unexpectedFileName', 'The filename \'{0}\' did not have the expected format.', filePath));
+    }
+
+    return splitFileName[2];
+}
+
 export async function viewAppLogs(application: DaprApplication): Promise<void> {
-    await Promise.resolve();
+    if (!application.runTemplatePath) {
+        throw new Error(localize('commands.applications.viewAppLogs.noRunFile', 'Logs can be viewed only when applications are started via a run file.'));
+    }
+
+    const runFile = await fromRunFilePath(application.runTemplatePath);
+
+    for (const app of runFile.apps ?? []) {
+        if (application.appId === getAppId(app)) {
+            if (!app.appDirPath) {
+                throw new Error(localize('commands.applications.viewAppLogs.appDirNotFound', 'The directory for application \'{0}\' was not found in the run file \'{1}\'.', application.appId, application.runTemplatePath));
+            }
+            const runFileDirectory = path.dirname(application.runTemplatePath);
+            const appDirectory = path.join(runFileDirectory, app.appDirPath, '.dapr', 'logs');
+
+            const pattern = `${application.appId}_app_*.log`;
+            const relativePattern = new vscode.RelativePattern(appDirectory, pattern);
+
+            const files = await vscode.workspace.findFiles(relativePattern);
+
+            const timestampedFiles = files.map(file => ({ file: file, timestamp: getTimestamp(file) }))
+
+            timestampedFiles.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+            if (timestampedFiles.length < 1) {
+                throw new Error(localize('commands.applications.viewAppLogs.logNotFound', 'No logs for application \'{0}\' were.', application.appId));
+            }
+
+            const logFile = timestampedFiles[0].file;
+
+            // TODO: Scroll to end.
+            await vscode.window.showTextDocument(logFile);
+
+            return;
+        }
+    }
+
+    throw new Error(localize('commands.applications.viewAppLogs.appNotFound', 'The application \'{0}\' was not found in the run file \'{1}\'.', application.appId, application.runTemplatePath));
 }
 
 const createViewAppLogsCommand = () => (context: IActionContext, node: DaprApplicationNode | undefined): Promise<void> => {

--- a/src/commands/applications/viewDaprLogs.ts
+++ b/src/commands/applications/viewDaprLogs.ts
@@ -1,24 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as nls from 'vscode-nls';
 import DaprApplicationNode from "../../views/applications/daprApplicationNode";
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { getLocalizationPathForFile } from '../../util/localization';
-import * as nls from 'vscode-nls';
-import { DaprApplication } from "../../services/daprApplicationProvider";
+import { viewLogs } from "./viewLogs";
 
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
-export async function viewDaprLogs(application: DaprApplication): Promise<void> {
-    await Promise.resolve();
-}
-
 const createViewDaprLogsCommand = () => (context: IActionContext, node: DaprApplicationNode | undefined): Promise<void> => {
     if (node == undefined) {
-        throw new Error(localize('commands.applications.viewDaprLogs.noPaletteSupport', 'Viewing logs requires selecting an application in the Dapr view.'));
+        throw new Error(localize('commands.applications.viewDaprLogs.noPaletteSupport', 'Viewing Dapr logs requires selecting an application in the Dapr view.'));
     }
 
-    return viewDaprLogs(node.application);
+    return viewLogs(node.application, 'daprd');
 }
 
 export default createViewDaprLogsCommand;

--- a/src/commands/applications/viewDaprLogs.ts
+++ b/src/commands/applications/viewDaprLogs.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import DaprApplicationNode from "../../views/applications/daprApplicationNode";
+import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { getLocalizationPathForFile } from '../../util/localization';
+import * as nls from 'vscode-nls';
+import { DaprApplication } from "../../services/daprApplicationProvider";
+
+const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
+
+export async function viewDaprLogs(application: DaprApplication): Promise<void> {
+    await Promise.resolve();
+}
+
+const createViewDaprLogsCommand = () => (context: IActionContext, node: DaprApplicationNode | undefined): Promise<void> => {
+    if (node == undefined) {
+        throw new Error(localize('commands.applications.viewDaprLogs.noPaletteSupport', 'Viewing logs requires selecting an application in the Dapr view.'));
+    }
+
+    return viewDaprLogs(node.application);
+}
+
+export default createViewDaprLogsCommand;

--- a/src/commands/applications/viewLogs.ts
+++ b/src/commands/applications/viewLogs.ts
@@ -17,7 +17,7 @@ export async function viewLogs(application: DaprApplication, type: DaprLogType):
         throw new Error(localize('commands.applications.viewLogs.noRunFile', 'Logs can be viewed only when applications are started via a run file.'));
     }
 
-    const runFile = await fromRunFilePath(application.runTemplatePath);
+    const runFile = await fromRunFilePath(vscode.Uri.file(application.runTemplatePath));
 
     const runFileApplication = (runFile.apps ?? []).find(app => application.appId === getAppId(app));
 

--- a/src/commands/applications/viewLogs.ts
+++ b/src/commands/applications/viewLogs.ts
@@ -43,6 +43,5 @@ export async function viewLogs(application: DaprApplication, type: DaprLogType):
 
     const newestFile = files.reduce((newestFile, nextFile) => newestFile.fsPath.localeCompare(nextFile.fsPath) < 0 ? nextFile : newestFile);
 
-    // TODO: Scroll to end.
     await vscode.window.showTextDocument(newestFile);
 }

--- a/src/commands/applications/viewLogs.ts
+++ b/src/commands/applications/viewLogs.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as nls from 'vscode-nls';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { getLocalizationPathForFile } from '../../util/localization';
+import { DaprApplication } from "../../services/daprApplicationProvider";
+import { fromRunFilePath, getAppId } from "../../util/runFileReader";
+
+const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
+
+export type DaprLogType = 'app' | 'daprd';
+
+export async function viewLogs(application: DaprApplication, type: DaprLogType): Promise<void> {
+    if (!application.runTemplatePath) {
+        throw new Error(localize('commands.applications.viewLogs.noRunFile', 'Logs can be viewed only when applications are started via a run file.'));
+    }
+
+    const runFile = await fromRunFilePath(application.runTemplatePath);
+
+    const runFileApplication = (runFile.apps ?? []).find(app => application.appId === getAppId(app));
+
+    if (!runFileApplication) {
+        throw new Error(localize('commands.applications.viewLogs.appNotFound', 'The application \'{0}\' was not found in the run file \'{1}\'.', application.appId, application.runTemplatePath));
+    }
+
+    if (!runFileApplication.appDirPath) {
+        throw new Error(localize('commands.applications.viewLogs.appDirNotFound', 'The directory for application \'{0}\' was not found in the run file \'{1}\'.', application.appId, application.runTemplatePath));
+    }
+
+    const runFileDirectory = path.dirname(application.runTemplatePath);
+    const appDirectory = path.join(runFileDirectory, runFileApplication.appDirPath, '.dapr', 'logs');
+
+    const pattern = `${application.appId}_${type}_*.log`;
+    const relativePattern = new vscode.RelativePattern(appDirectory, pattern);
+
+    const files = await vscode.workspace.findFiles(relativePattern);
+
+    if (files.length === 0) {
+        throw new Error(localize('commands.applications.viewLogs.logNotFound', 'No logs for application \'{0}\' were found.', application.appId));
+    }
+
+    const newestFile = files.reduce((newestFile, nextFile) => newestFile.fsPath.localeCompare(nextFile.fsPath) < 0 ? nextFile : newestFile);
+
+    // TODO: Scroll to end.
+    await vscode.window.showTextDocument(newestFile);
+}

--- a/src/debug/daprDebugConfigurationProvider.ts
+++ b/src/debug/daprDebugConfigurationProvider.ts
@@ -26,7 +26,7 @@ async function getAppIdsToDebug(configuration: DaprDebugConfiguration): Promise<
         return new Set<string>(configuration.includeApps);
     }
 
-    const runFile = await fromRunFilePath(configuration.runFile);
+    const runFile = await fromRunFilePath(vscode.Uri.file(configuration.runFile));
 
     const appIds = new Set<string>();
 

--- a/src/debug/daprDebugConfigurationProvider.ts
+++ b/src/debug/daprDebugConfigurationProvider.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import * as nls from 'vscode-nls';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { getLocalizationPathForFile } from '../util/localization';
 import { DaprApplication, DaprApplicationProvider } from '../services/daprApplicationProvider';
@@ -11,7 +10,7 @@ import { debugApplication } from '../commands/applications/debugApplication';
 import { UserInput } from '../services/userInput';
 import { withAggregateTokens } from '../util/aggregateCancellationTokenSource';
 import { fromCancellationToken } from '../util/observableCancellationToken';
-import { DaprRunApplication, fromRunFilePath, getAppId } from '../util/runFileReader';
+import { fromRunFilePath, getAppId } from '../util/runFileReader';
 
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,8 @@ import { AsyncDisposable } from './util/asyncDisposable';
 import createStartRunCommand from './commands/applications/startRun';
 import createStopRunCommand from './commands/applications/stopRun';
 import { DaprDebugConfigurationProvider } from './debug/daprDebugConfigurationProvider';
+import createViewAppLogsCommand from './commands/applications/viewAppLogs';
+import createViewDaprLogsCommand from './commands/applications/viewDaprLogs';
 
 interface ExtensionPackage {
 	engines: { [key: string]: string };
@@ -102,6 +104,8 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			telemetryProvider.registerCommandWithTelemetry('vscode-dapr.applications.publish-all-message', createPublishAllMessageCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.publish-message', createPublishMessageCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.stop-app', createStopCommand(daprCliClient, ui));
+			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.view-app-logs', createViewAppLogsCommand());
+			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.view-dapr-logs', createViewDaprLogsCommand());
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.help.readDocumentation', createReadDocumentationCommand(ui));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.help.getStarted', createGetStartedCommand(ui));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.help.installDapr', createInstallDaprCommand(ui));

--- a/src/util/runFileReader.ts
+++ b/src/util/runFileReader.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as fs from 'fs/promises';
+import * as nls from 'vscode-nls';
+import * as path from 'path';
+import { getLocalizationPathForFile } from '../util/localization';
+import { load } from "js-yaml";
+
+const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
+
+export interface DaprRunApplication {
+    appDirPath?: string;
+    appID?: string;
+}
+
+export interface DaprRunFile {
+    apps?: DaprRunApplication[];
+}
+
+export async function fromRunFilePath(path: string): Promise<DaprRunFile>{
+    const runFileContent = await fs.readFile(path, { encoding: 'utf8' });
+
+    if (!runFileContent) {
+        throw new Error(localize('util.runFileReader.noContent', 'There is no run file content at path: {0}', path));
+    }
+
+    return fromRunFileContent(runFileContent);
+}
+
+export function fromRunFileContent(content: string): DaprRunFile {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    const runFile = load(content) as DaprRunFile;
+
+    return runFile;
+}
+
+export function getAppId(app: DaprRunApplication): string {
+    if (app.appID) {
+        return app.appID;
+    }
+
+    if (app.appDirPath) {
+        return path.basename(app.appDirPath);
+    }
+
+    throw new Error(localize('util.runFileReader.unableToDetermineAppId', 'Unable to determine a configured application\'s ID.'));
+}

--- a/src/util/runFileReader.ts
+++ b/src/util/runFileReader.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as fs from 'fs/promises';
 import * as nls from 'vscode-nls';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { getLocalizationPathForFile } from '../util/localization';
 import { load } from "js-yaml";
 
@@ -18,14 +18,14 @@ export interface DaprRunFile {
     apps?: DaprRunApplication[];
 }
 
-export async function fromRunFilePath(path: string): Promise<DaprRunFile>{
-    const runFileContent = await fs.readFile(path, { encoding: 'utf8' });
+export async function fromRunFilePath(path: vscode.Uri): Promise<DaprRunFile>{
+    const runFileContent = await vscode.workspace.fs.readFile(path);
 
     if (!runFileContent) {
-        throw new Error(localize('util.runFileReader.noContent', 'There is no run file content at path: {0}', path));
+        throw new Error(localize('util.runFileReader.noContent', 'There is no run file content at path: {0}', path.fsPath));
     }
 
-    return fromRunFileContent(runFileContent);
+    return fromRunFileContent(runFileContent.toString());
 }
 
 export function fromRunFileContent(content: string): DaprRunFile {

--- a/src/views/applications/daprApplicationNode.ts
+++ b/src/views/applications/daprApplicationNode.ts
@@ -14,7 +14,11 @@ export default class DaprApplicationNode implements TreeNode {
     getTreeItem(): Promise<vscode.TreeItem> {
         const item = new vscode.TreeItem(this.application.appId, vscode.TreeItemCollapsibleState.Collapsed);
 
-        item.contextValue = ['application', this.application.appPid !== undefined ? 'attachable' : ''].join(' ');
+        item.contextValue = [
+            'application',
+            this.application.appPid !== undefined ? 'attachable' : '',
+            this.application.runTemplatePath ? 'hasLogs' : ''
+        ].join(' ');
         item.iconPath = new vscode.ThemeIcon(this.application.appPid !== undefined ? 'server-process' : 'browser');
 
         return Promise.resolve(item);


### PR DESCRIPTION
Enable to the user to open the application and Dapr sidecar logs directly from the application context menu in the Dapr view.  The newest file found (based on timespan embedded in the filename) will be opened.

<img width="512" alt="Screenshot 2023-02-13 at 21 35 06" src="https://user-images.githubusercontent.com/6402946/218650958-fb1c6acd-c5c3-44c4-869f-d6de4a17515c.png">

<img width="1085" alt="Screenshot 2023-02-13 at 21 35 49" src="https://user-images.githubusercontent.com/6402946/218650963-e0c7661c-85eb-4917-ae92-cc5c4c9049ab.png">

Resolves #285 