### PR TITLE
Adds ability to browse to Dapr application entrypoint.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
         '@typescript-eslint'
     ],
     rules: {
+        "eqeqeq": ["error"],
         "@typescript-eslint/restrict-template-expressions": ["error", { "allowBoolean": true }]
     }
 };

--- a/package.json
+++ b/package.json
@@ -235,12 +235,12 @@
 				{
 					"command": "vscode-dapr.applications.browse",
 					"when": "view == vscode-dapr.views.applications && viewItem =~ /application/ && viewItem =~ /browsable/",
-					"group": "inline"
+					"group": "inline@1"
 				},
 				{
 					"command": "vscode-dapr.applications.debug",
 					"when": "view == vscode-dapr.views.applications && viewItem =~ /application/ && viewItem =~ /attachable/",
-					"group": "inline"
+					"group": "inline@2"
 				},
 				{
 					"command": "vscode-dapr.applications.invoke-get",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,12 @@
 	"contributes": {
 		"commands": [
 			{
+				"command": "vscode-dapr.applications.browse",
+				"title": "%vscode-dapr.applications.browse.title%",
+				"category": "Dapr",
+				"icon": "$(globe)"
+			},
+			{
 				"command": "vscode-dapr.applications.debug",
 				"title": "%vscode-dapr.applications.debug.title%",
 				"category": "Dapr",
@@ -191,6 +197,10 @@
 		"menus": {
 			"commandPalette": [
 				{
+					"command": "vscode-dapr.applications.browse",
+					"when": "never"
+				},
+				{
 					"command": "vscode-dapr.applications.debug",
 					"when": "never"
 				},
@@ -222,6 +232,11 @@
 				}
 			],
 			"view/item/context": [
+				{
+					"command": "vscode-dapr.applications.browse",
+					"when": "view == vscode-dapr.views.applications && viewItem =~ /application/ && viewItem =~ /browsable/",
+					"group": "inline"
+				},
 				{
 					"command": "vscode-dapr.applications.debug",
 					"when": "view == vscode-dapr.views.applications && viewItem =~ /application/ && viewItem =~ /attachable/",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,5 @@
 {
-    "vscode-dapr.applications.browse.title": "Browse to Application",
+    "vscode-dapr.applications.browse.title": "Open Application in Browser",
     "vscode-dapr.applications.debug.title": "Debug Application",
     "vscode-dapr.applications.invoke-get.title": "Invoke (GET) Application Method",
     "vscode-dapr.applications.invoke-post.title": "Invoke (POST) Application Method",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,4 +1,5 @@
 {
+    "vscode-dapr.applications.browse.title": "Browse to Application",
     "vscode-dapr.applications.debug.title": "Debug Application",
     "vscode-dapr.applications.invoke-get.title": "Invoke (GET) Application Method",
     "vscode-dapr.applications.invoke-post.title": "Invoke (POST) Application Method",

--- a/src/commands/applications/browseToApplication.ts
+++ b/src/commands/applications/browseToApplication.ts
@@ -20,7 +20,7 @@ async function browseToApplication(application: DaprApplication, ui: UserInput):
 }
 
 const createBrowseToApplicationCommand = (ui: UserInput) => (context: IActionContext, node: DaprApplicationNode | undefined): Promise<void> => {
-    if (node == undefined) {
+    if (node === undefined) {
         throw new Error(localize('commands.applications.browseToApplication.noPaletteSupport', 'Browsing requires selecting an application in the Dapr view.'));
     }
 

--- a/src/commands/applications/browseToApplication.ts
+++ b/src/commands/applications/browseToApplication.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as nls from 'vscode-nls';
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { DaprApplication } from "../../services/daprApplicationProvider";
+import DaprApplicationNode from "../../views/applications/daprApplicationNode";
+import { getLocalizationPathForFile } from '../../util/localization';
+import { UserInput } from '../../services/userInput';
+
+const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
+
+async function browseToApplication(application: DaprApplication, ui: UserInput): Promise<void> {
+    if (application.appPort === undefined) {
+        throw new Error(localize('commands.applications.browseToApplication.noAppPort', 'No port is associated with the application \'{0}\'.', application.appId));
+    }
+
+    // TODO: Is this app always HTTP?
+    await ui.openExternal(`http://localhost:${application.appPort}`);
+}
+
+const createBrowseToApplicationCommand = (ui: UserInput) => (context: IActionContext, node: DaprApplicationNode | undefined): Promise<void> => {
+    if (node == undefined) {
+        throw new Error(localize('commands.applications.browseToApplication.noPaletteSupport', 'Browsing requires selecting an application in the Dapr view.'));
+    }
+
+    return browseToApplication(node.application, ui);
+}
+
+export default createBrowseToApplicationCommand;

--- a/src/commands/applications/debugApplication.ts
+++ b/src/commands/applications/debugApplication.ts
@@ -108,7 +108,7 @@ export async function debugApplication(application: DaprApplication): Promise<vo
 }
 
 const createDebugApplicationCommand = () => (context: IActionContext, node: DaprApplicationNode | undefined): Promise<void> => {
-    if (node == undefined) {
+    if (node ===undefined) {
         throw new Error(localize('commands.applications.viewLogs.noPaletteSupport', 'Debugging requires selecting an application in the Dapr view.'));
     }
 

--- a/src/commands/applications/debugRun.ts
+++ b/src/commands/applications/debugRun.ts
@@ -17,7 +17,7 @@ async function debugRun(applications: DaprApplication[]): Promise<void> {
 }
 
 const createDebugRunCommand = () => (context: IActionContext, node: DaprRunNode | undefined): Promise<void> => {
-    if (node == undefined) {
+    if (node === undefined) {
         throw new Error(localize('commands.applications.debugRun.noPaletteSupport', 'Debugging requires selecting a run in the Dapr view.'));
     }
 

--- a/src/commands/applications/stopRun.ts
+++ b/src/commands/applications/stopRun.ts
@@ -27,7 +27,7 @@ async function stopRun(context: IActionContext, label: string, runTemplatePath: 
 }
 
 const createStopRunCommand = (daprCliClient: DaprCliClient) => (context: IActionContext, node: DaprRunNode | undefined): Promise<void> => {
-    if (node == undefined || node.runTemplatePath === undefined) {
+    if (node === undefined || node.runTemplatePath === undefined) {
         throw new Error(localize('commands.applications.stopRun.noPaletteSupport', 'Stopping requires selecting a valid run in the Dapr view.'));
     }
 

--- a/src/commands/applications/viewAppLogs.ts
+++ b/src/commands/applications/viewAppLogs.ts
@@ -10,7 +10,7 @@ import { viewLogs } from './viewLogs';
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
 const createViewAppLogsCommand = () => (context: IActionContext, node: DaprApplicationNode | undefined): Promise<void> => {
-    if (node == undefined) {
+    if (node === undefined) {
         throw new Error(localize('commands.applications.viewAppLogs.noPaletteSupport', 'Viewing application logs requires selecting an application in the Dapr view.'));
     }
 

--- a/src/commands/applications/viewDaprLogs.ts
+++ b/src/commands/applications/viewDaprLogs.ts
@@ -10,7 +10,7 @@ import { viewLogs } from "./viewLogs";
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
 const createViewDaprLogsCommand = () => (context: IActionContext, node: DaprApplicationNode | undefined): Promise<void> => {
-    if (node == undefined) {
+    if (node === undefined) {
         throw new Error(localize('commands.applications.viewDaprLogs.noPaletteSupport', 'Viewing Dapr logs requires selecting an application in the Dapr view.'));
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,7 @@ import createStopRunCommand from './commands/applications/stopRun';
 import { DaprDebugConfigurationProvider } from './debug/daprDebugConfigurationProvider';
 import createViewAppLogsCommand from './commands/applications/viewAppLogs';
 import createViewDaprLogsCommand from './commands/applications/viewDaprLogs';
+import createBrowseToApplicationCommand from './commands/applications/browseToApplication';
 
 interface ExtensionPackage {
 	engines: { [key: string]: string };
@@ -98,6 +99,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 				ui);
 			const daprCommandTaskProvider = new DaprCommandTaskProvider(daprInstallationManager, () => settingsProvider.daprPath, telemetryProvider);
 
+			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.browse', createBrowseToApplicationCommand(ui));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.debug', createDebugApplicationCommand());
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.invoke-get', createInvokeGetCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));
 			telemetryProvider.registerContextCommandWithTelemetry('vscode-dapr.applications.invoke-post', createInvokePostCommand(daprApplicationProvider, daprClient, ext.outputChannel, ui, context.workspaceState));

--- a/src/services/daprApplicationProvider.ts
+++ b/src/services/daprApplicationProvider.ts
@@ -61,7 +61,7 @@ export default class DaprListBasedDaprApplicationProvider implements DaprApplica
 
         const result = await Process.exec(command);
 
-        if (result.code != 0) {
+        if (result.code !== 0) {
             throw new Error(`'${command}' failed with exit code ${result.code}.`);
         }
 

--- a/src/views/applications/daprApplicationNode.ts
+++ b/src/views/applications/daprApplicationNode.ts
@@ -17,6 +17,7 @@ export default class DaprApplicationNode implements TreeNode {
         item.contextValue = [
             'application',
             this.application.appPid !== undefined ? 'attachable' : '',
+            this.application.appPort !== undefined ? 'browsable' : '',
             this.application.runTemplatePath ? 'hasLogs' : ''
         ].join(' ');
         item.iconPath = new vscode.ThemeIcon(this.application.appPid !== undefined ? 'server-process' : 'browser');


### PR DESCRIPTION
For applications that expose a port, we add an inline context command to open a browser directly to that entrypoint, saving the developer the step of typing out the path in a browser.

> Note: there's no guarantee that the base endpoint is served by the application but, currently, there's no place for developers to indicate an appropriate subpath.  (That will hopefully be added to the Dapr runtime in due course.)

> Note: the extension also assume the application exposes an HTTP port.  (It might expose a gRPC port instead but, again, the Dapr runtime doesn't provide a way to distinguish between them.)

<img width="477" alt="Screenshot 2023-02-16 at 11 25 42" src="https://user-images.githubusercontent.com/6402946/219473174-5b3e3cf6-f992-44e7-a5dd-3e6e66668ad6.png">

Resolves #275 