### PR TITLE
Revert to(non-ESM) ps-list 7.2.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"handlebars": "^4.7.7",
 				"js-yaml": "^4.1.0",
 				"lodash.isequal": "^4.5.0",
-				"ps-list": "^8.1.1",
+				"ps-list": "^7.2.0",
 				"rxjs": "^7.8.0",
 				"semver": "^7.3.5",
 				"tree-kill": "^1.2.2",
@@ -4478,11 +4478,11 @@
 			"dev": true
 		},
 		"node_modules/ps-list": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/ps-list/-/ps-list-8.1.1.tgz",
-			"integrity": "sha512-OPS9kEJYVmiO48u/B9qneqhkMvgCxT+Tm28VCEJpheTpl8cJ0ffZRRNgS5mrQRTrX5yRTpaJ+hRDeefXYmmorQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/ps-list/-/ps-list-7.2.0.tgz",
+			"integrity": "sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ==",
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -9746,9 +9746,9 @@
 			"dev": true
 		},
 		"ps-list": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/ps-list/-/ps-list-8.1.1.tgz",
-			"integrity": "sha512-OPS9kEJYVmiO48u/B9qneqhkMvgCxT+Tm28VCEJpheTpl8cJ0ffZRRNgS5mrQRTrX5yRTpaJ+hRDeefXYmmorQ=="
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/ps-list/-/ps-list-7.2.0.tgz",
+			"integrity": "sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ=="
 		},
 		"punycode": {
 			"version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -770,7 +770,7 @@
 		"handlebars": "^4.7.7",
 		"js-yaml": "^4.1.0",
 		"lodash.isequal": "^4.5.0",
-		"ps-list": "^8.1.1",
+		"ps-list": "^7.2.0",
 		"rxjs": "^7.8.0",
 		"semver": "^7.3.5",
 		"tree-kill": "^1.2.2",

--- a/src/views/applications/daprApplicationNode.ts
+++ b/src/views/applications/daprApplicationNode.ts
@@ -17,7 +17,7 @@ export default class DaprApplicationNode implements TreeNode {
         item.contextValue = [
             'application',
             this.application.appPid !== undefined ? 'attachable' : '',
-            this.application.appPort !== undefined ? 'browsable' : '',
+            this.application.appPort !== undefined && this.application.appPort > 0 ? 'browsable' : '',
             this.application.runTemplatePath ? 'hasLogs' : ''
         ].join(' ');
         item.iconPath = new vscode.ThemeIcon(this.application.appPid !== undefined ? 'server-process' : 'browser');


### PR DESCRIPTION
Windows doesn't seem to like use of the latest `ps-list` which is a pure ES module.  Strangely, Mac and Linux seem to be fine with it.

Also fixes a bug where the "browse" button was shown when it shouldn't.