### PR TITLE
Update problem matcher to accommodate 1.12 changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v0.8.0 - 3 October 2023
+## v0.8.0 - 16 October 2023
 
 Integrating new features of Dapr 1.11 and 1.12.
 
@@ -10,6 +10,10 @@ Integrating new features of Dapr 1.11 and 1.12.
 * [Enhancement] Update Dapr run file template schema to match changes in v1.11 [#296](https://github.com/microsoft/vscode-dapr/issues/296)
 * [Enhancement] Scaffold Dapr tasks using existing run file [#272](https://github.com/microsoft/vscode-dapr/issues/272)
 * chore: enhance dapryml schema validation [#292](https://github.com/microsoft/vscode-dapr/pull/292)
+
+### Fixed
+
+* Debugging with Dapr hangs with 1.12 [#309](https://github.com/microsoft/vscode-dapr/issues/309)
 
 ## v0.7.0 - 16 February 2023
 

--- a/package.json
+++ b/package.json
@@ -312,8 +312,8 @@
 					}
 				],
 				"background": {
-					"beginsPattern": "^.*starting Dapr Runtime",
-					"endsPattern": "^.*(waiting on port|dapr initialized)"
+					"beginsPattern": { "regexp": "^.*[sS]tarting Dapr Runtime" },
+					"endsPattern": { "regexp": "^.*(waiting on port|dapr initialized)" }
 				}
 			}
 		],


### PR DESCRIPTION
Dapr 1.12 changed the "starting Dapr Runtime" log message which meant that VS Code could no longer detect when the Dapr task had started (and therefore finished), and so would never complete and move onto starting the application itself.  This fix accommodates both pre- and post-1.12 log messages.  (Also updated to use the newer definition syntax.)

Resolves #309 